### PR TITLE
Persistence in Conversations

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,14 @@ const client = new Client({
     ]
 });
 
-registerEvents(client, Events)
+const messageHistory = [
+    {
+        role: 'assistant',
+        content: 'My name is Ollama GU.'
+    }
+]
+
+registerEvents(client, Events, messageHistory)
 
 // Try to log in the client
 client.login(Keys.clientToken)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -8,35 +8,31 @@ export default event(Events.MessageCreate, ({ log }, message) => {
     log(`Message created \"${message.content}\" from ${message.author.tag}.`)
 
     // Hard-coded channel to test output there only, in our case "ollama-endpoint"
-    if (message.channelId != '1188262786497785896') {
-        log(`Unauthorized Channel input, Aborting...`)
-        return
-    }
-    log(`Channel id OK!`)
+    if (message.channelId != '1188262786497785896') return
 
     // Do not respond if bot talks in the chat
-    if (message.author.tag === message.client.user.tag) {
-        log(`Found Bot message reply, Aborting...`)
-        return
-    }
-    log(`Sender Checked!`)
+    if (message.author.tag === message.client.user.tag) return
 
-    // Request made to API
-    const request = async () => {
-        try {
-            const response = await Axios.post('http://127.0.0.1:11434/api/generate', {
-                model: 'llama2',
-                prompt: message.content,
-                stream: false
-            })
-            log(response.data)
-            //
-            message.reply(response.data['response'])
-        } catch (error) {
-            log(error)
-        }
-    }
+    // Reply with something to prompt that ollama is working
+    message.reply("Generating Response...").then(sentMessage => {
+        // Request made to API
+        const request = async () => {
+            try {
+                // change this when using an actual hosted server or use ollama.js
+                const response = await Axios.post('http://127.0.0.1:11434/api/generate', {
+                    model: 'llama2',
+                    prompt: message.content,
+                    stream: false
+                })
+                log(response.data)
     
-    // Attempt to call ollama's endpoint
-    request()
+                sentMessage.edit(response.data.response)
+            } catch (error) {
+                log(error)
+            }
+        }
+
+        // Attempt to call ollama's endpoint
+        request()
+    })
 })

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,43 +1,44 @@
-import type { ClientEvents, Awaitable, Client } from 'discord.js';
+import type { ClientEvents, Awaitable, Client } from 'discord.js'
 
 // Export events through here to reduce amount of imports
-export { Events } from 'discord.js';
+export { Events } from 'discord.js'
 
-export type LogMethod = (...args: unknown[]) => void;
-export type EventKeys = keyof ClientEvents; // only wants keys of ClientEvents object
+export type LogMethod = (...args: unknown[]) => void
+export type EventKeys = keyof ClientEvents // only wants keys of ClientEvents object
 
 // Event properties
 export interface EventProps {
-    client: Client;
-    log: LogMethod;
+    client: Client
+    log: LogMethod
+    msgHist: { role: string, content: string }[]
 }
 export type EventCallback<T extends EventKeys> = (
     props: EventProps,
     ...args: ClientEvents[T]
-) => Awaitable<unknown>; // Method can be synchronous or async, unknown so we can return anything
+) => Awaitable<unknown> // Method can be synchronous or async, unknown so we can return anything
 
 // Event interface
 export interface Event<T extends EventKeys = EventKeys> {
-    key: T;
-    callback: EventCallback<T>;
+    key: T
+    callback: EventCallback<T>
 }
 
 export function event<T extends EventKeys>(key: T, callback: EventCallback<T>): Event<T> {
-    return { key, callback };
+    return { key, callback }
 }
 
-export function registerEvents(client: Client, events: Event[]): void {
+export function registerEvents(client: Client, events: Event[], msgHist: { role: string, content: string }[]): void {
     for (const { key, callback } of events) {
         client.on(key, (...args) => {
             // Create a new log method for this event
-            const log = console.log.bind(console, `[Event: ${key}]`);
+            const log = console.log.bind(console, `[Event: ${key}]`)
 
             // Handle Errors, call callback, log errors as needed
             try {
-                callback({ client, log }, ...args);
+                callback({ client, log, msgHist }, ...args)
             } catch (error) {
-                log('[Uncaught Error]', error);
+                log('[Uncaught Error]', error)
             }
-        });
+        })
     }
 }


### PR DESCRIPTION
## Added
* State where `roles` and `content` can be stored so the model knows prior conversations.
* Bot can be given prior history before starting like a name.

## Notes
* `msgHist` will likely persist for all messages while it is alive, this should be only per individual. This solution is just to prove that it can work given the chat endpoint in ollama.
* I will be looking into Vector Databasing and Embedding to store data.
* I will also look into the generate endpoint and figure out how persistent conversations happen there.