### PR TITLE
CI for Application Builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,81 @@
+name: Test Discord-Ollama Builds
+run-name: Validate Node and Docker Builds
+on:
+    push:
+        branches:
+            - master
+
+jobs: 
+    Discord-Node-Build: # test if the node install and run
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v4
+
+            - name: Set up Node Environment v18.18.2
+              uses: actions/setup-node@v4
+              with:
+                node-version: 18.18.2
+                cache: 'npm'
+
+            - name: Install Project Dependencies
+              run: |
+                npm install
+
+            - name: Build Application
+              run: |
+                npm run build
+
+            - name: Create Environment Variables
+              run: |
+                touch .env
+                echo CLIENT_TOKEN = ${{ secrets.BOT_TOKEN }} >> .env
+                echo GUILD_ID = ${{ secrets.GUILD_ID }} >> .env
+                echo CHANNEL_ID = ${{ secrets.CHANNEL_ID }} >> .env
+                echo MODEL = ${{ secrets.MODEL }} >> .env
+                echo CLIENT_UID = ${{ secrets.CLIENT_UID }} >> .env
+                echo OLLAMA_IP = ${{ secrets.OLLAMA_IP }} >> .env
+                echo OLLAMA_PORT = ${{ secrets.OLLAMA_PORT }} >> .env
+
+            - name: Startup Discord Bot Client
+              run: |
+                nohup npm run prod &
+
+    Discord-Ollama-Container-Build: # test docker build and run
+      runs-on: ubuntu-latest
+      timeout-minutes: 2
+      steps:
+          - name: Checkout Repository
+            uses: actions/checkout@v4
+
+          - name: Set up Node Environment v18.18.2
+            uses: actions/setup-node@v4
+            with:
+              node-version: 18.18.2
+              cache: 'npm'
+
+          - name: Create Environment Variables
+            run: |
+              touch .env
+              echo CLIENT_TOKEN = ${{ secrets.BOT_TOKEN }} >> .env
+              echo GUILD_ID = ${{ secrets.GUILD_ID }} >> .env
+              echo CHANNEL_ID = ${{ secrets.CHANNEL_ID }} >> .env
+              echo MODEL = ${{ secrets.MODEL }} >> .env
+              echo CLIENT_UID = ${{ secrets.CLIENT_UID }} >> .env
+              echo OLLAMA_IP = ${{ secrets.OLLAMA_IP }} >> .env
+              echo OLLAMA_PORT = ${{ secrets.OLLAMA_PORT }} >> .env
+
+          - name: Setup Docker Network and Images
+            run: |
+              npm run docker:start-cpu
+          
+          - name: Check Images Exist
+            run: |
+              (docker images | grep -q 'discord/bot' && docker images | grep -qE 'ollama/ollama') || exit 1
+
+
+          - name: Check Images Exist
+            run: |
+              (docker ps | grep -q 'ollama' && docker ps | grep -q 'discord') || exit 1
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",
@@ -13,11 +13,13 @@
     "clean": "docker compose down && docker rmi $(docker images | grep 0.2.0 | tr -s ' ' | cut -d ' ' -f 3) && docker rmi $(docker images --filter \"dangling=true\" -q --no-trunc)",
     "start": "docker compose build --no-cache && docker compose up -d",
     "docker:start": "npm run docker:network && npm run docker:build && npm run docker:client && npm run docker:ollama",
+    "docker:start-cpu": "npm run docker:network && npm run docker:build && npm run docker:client && npm run docker:ollama-cpu",
     "docker:clean": "docker rmi $(docker images --filter \"dangling=true\" -q --no-trunc)",
     "docker:network": "docker network create --subnet=172.18.0.0/16 ollama-net",
-    "docker:build": "docker build --no-cache -t discord/bot:0.2.0 .",
-    "docker:client": "docker run -d -v discord:/src/app --name discord --network ollama-net --ip 172.18.0.3 discord",
-    "docker:ollama": "docker run -d --gpus=all -v ollama:/root/.ollama -p 11434:11434 --name ollama --network ollama-net --ip 172.18.0.2 ollama/ollama:latest"
+    "docker:build": "docker build --no-cache -t discord/bot:0.3.2 .",
+    "docker:client": "docker run -d -v discord:/src/app --name discord --network ollama-net --ip 172.18.0.3 discord/bot:0.3.2",
+    "docker:ollama": "docker run -d --gpus=all -v ollama:/root/.ollama -p 11434:11434 --name ollama --network ollama-net --ip 172.18.0.2 ollama/ollama:latest",
+    "docker:ollama-cpu": "docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama --network ollama-net --ip 172.18.0.2 ollama/ollama:latest"
   },
   "author": "Kevin Dang",
   "license": "ISC",


### PR DESCRIPTION
## Added
* `build-test.yml` to verify the integrity of the current release build.
* Limited the workflow jobs to 2 minutes in case anything goes wrong.

## Notes
* This will not test for the "Nvidia GPU" build as we would need a server with an Nvidia GPU as a `self-hosted` runner to validate that it is working as intended.
* This does not mean we won't implement those tests, but for now we have these to make sure the builds are running correctly.
* This only addresses a part of the CI portion of this issue #24. We will work on Continuous Deployment later when we need to continually deploy new features that are passing build tests.