### PR TITLE
Shutoff Discord Bot

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,3 +22,6 @@ DISCORD_IP = IP_ADDRESS
 
 # subnet address, ex. 172.18.0.0 as we use /16.
 SUBNET_ADDRESS = ADDRESS
+
+# list of admins to handle admin commands for the bot, use single quotes
+ADMINS=['username1', 'username2', 'username3', ...]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: Test Discord-Ollama Builds
+name: Builds
 run-name: Validate Node and Docker Builds
 on:
     push:
@@ -73,7 +73,6 @@ jobs:
           - name: Check Images Exist
             run: |
               (docker images | grep -q 'discord/bot' && docker images | grep -qE 'ollama/ollama') || exit 1
-
 
           - name: Check Containers Exist
             run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: discord/bot:0.2.0
+    image: discord/bot:0.3.4
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       GUILD_ID: ${GUILD_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -22,7 +22,7 @@ export const Disable: SlashCommand = {
         const channel = await client.channels.fetch(interaction.channelId)
         if (!channel || channel.type !== ChannelType.GuildText) return
 
-        // set the message style
+        // set state of bot chat features
         openFile('config.json', interaction.commandName, interaction.options.get('enabled')?.value)
 
         interaction.reply({

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -1,0 +1,33 @@
+import { ChannelType, Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
+import { SlashCommand } from '../utils/commands.js'
+import { openFile } from '../utils/jsonHandler.js'
+
+export const Disable: SlashCommand = {
+    name: 'toggle-chat',
+    description: 'toggle all chat features, slash commands will still work.',
+
+    // set available user options to pass to the command
+    options: [
+        {
+            name: 'enabled',
+            description: 'true = enabled, false = disabled',
+            type: ApplicationCommandOptionType.Boolean,
+            required: true
+        }
+    ],
+
+    // Query for message information and set the style
+    run: async (client: Client, interaction: CommandInteraction) => {
+        // fetch channel and message
+        const channel = await client.channels.fetch(interaction.channelId)
+        if (!channel || channel.type !== ChannelType.GuildText) return
+
+        // set the message style
+        openFile('config.json', interaction.commandName, interaction.options.get('enabled')?.value)
+
+        interaction.reply({
+            content: `Chat features has been \`${interaction.options.get('enabled')?.value ?  "enabled" : "disabled" }\``,
+            ephemeral: true
+        })
+    }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,10 +3,12 @@ import { ThreadCreate } from './threadCreate.js'
 import { MessageStyle } from './messageStyle.js'
 import { MessageStream } from './messageStream.js'
 import { Disable } from './disable.js'
+import { Shutoff } from './shutoff.js'
 
 export default [
     ThreadCreate,
     MessageStyle,
     MessageStream,
-    Disable
+    Disable,
+    Shutoff
 ] as SlashCommand[]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,9 +2,11 @@ import { SlashCommand } from '../utils/commands.js'
 import { ThreadCreate } from './threadCreate.js'
 import { MessageStyle } from './messageStyle.js'
 import { MessageStream } from './messageStream.js'
+import { Disable } from './disable.js'
 
 export default [
     ThreadCreate,
     MessageStyle,
-    MessageStream
+    MessageStream,
+    Disable
 ] as SlashCommand[]

--- a/src/commands/shutoff.ts
+++ b/src/commands/shutoff.ts
@@ -1,0 +1,48 @@
+import { ChannelType, Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
+import { SlashCommand } from '../utils/commands.js'
+import Keys from '../keys.js'
+
+export const Shutoff: SlashCommand = {
+    name: 'shutoff',
+    description: 'shutdown the bot. You will need to manually bring it online again.',
+
+    // set available user options to pass to the command
+    options: [
+        {
+            name: 'are-you-sure',
+            description: 'true = yes, false = I\'m scared',
+            type: ApplicationCommandOptionType.Boolean,
+            required: true
+        }
+    ],
+
+    // Query for message information and set the style
+    run: async (client: Client, interaction: CommandInteraction) => {
+        // fetch channel and message
+        const channel = await client.channels.fetch(interaction.channelId)
+        if (!channel || channel.type !== ChannelType.GuildText) return
+
+        // log this, this will probably be improtant for logging who did this
+        console.log(`User -> ${interaction.user.tag} attempting to shutdown ${client.user!!.tag}`)
+
+        // create list of superUsers based on string parse
+        const superUsers: string[] = JSON.parse(Keys.superUser.replace(/'/g, '"'))
+
+        // validate superuser
+        if (interaction.user.tag in superUsers) {
+            interaction.reply({
+                content: `${interaction.user.tag}: You do not have permission to shutoff **${client.user?.tag}**`,
+                ephemeral: true
+            })
+            return // stop from shutting down
+        }
+
+        interaction.reply({
+            content: `${client.user?.tag} is ${interaction.options.get('are-you-sure')?.value ?  "shutting down now." : "not shutting down." }`,
+            ephemeral: true
+        })
+
+        // clean up client instance and stop
+        client.destroy()
+    }
+}

--- a/src/commands/shutoff.ts
+++ b/src/commands/shutoff.ts
@@ -28,10 +28,10 @@ export const Shutoff: SlashCommand = {
         // create list of superUsers based on string parse
         const superUsers: string[] = JSON.parse(Keys.superUser.replace(/'/g, '"'))
 
-        // validate superuser
-        if (interaction.user.tag in superUsers) {
+        // check if admin or false on shutdown
+        if (interaction.user.tag in superUsers || !(!interaction.options.get('are-you-sure')?.value && interaction.user.tag in superUsers)) {
             interaction.reply({
-                content: `${interaction.user.tag}: You do not have permission to shutoff **${client.user?.tag}**`,
+                content: `Shutdown failed:\n\n${interaction.user.tag}, You do not have permission to shutoff **${client.user?.tag}**, otherwise, you just didn't want to.`,
                 ephemeral: true
             })
             return // stop from shutting down

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -28,8 +28,15 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
     try {
         const config: Configuration = await new Promise((resolve, reject) => {
             getConfig('config.json', (config) => {
+                // check if config.json exists
                 if (config === undefined) {
-                    reject(new Error('No Configuration is set up.'))
+                    reject(new Error('No Configuration is set up.\n\nCreating \`config.json\` with \`message-style\` set as \`true\` for embedded messages.\nPlease try chatting again.'))
+                    return
+                }
+
+                // check if chat is disabled
+                if(!config.options['toggle-chat']) {
+                    reject(new Error('Admin(s) have disabled chat features.\n\n Please contact your server\'s admin(s).'))
                     return
                 }
                 resolve(config)
@@ -55,6 +62,6 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
     } catch (error: any) {
         msgHist.pop() // remove message because of failure
         openFile('config.json', 'message-style', true)
-        message.reply(`**Response generation failed.**\n\n**Reason:** *${error.message}*\n\nCreating \`config.json\` with \`message-style\` set as \`true\` for embedded messages.\nPlease try chatting again.`)
+        message.reply(`**Response generation failed.**\n\n**Reason:** *${error.message}*`)
     }
 })

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -7,7 +7,8 @@ export const Keys = {
     clientUid: getEnvVar('CLIENT_UID'),
     guildId: getEnvVar('GUILD_ID'),
     ipAddress: getEnvVar('OLLAMA_IP'),
-    portAddress: getEnvVar('OLLAMA_PORT')
+    portAddress: getEnvVar('OLLAMA_PORT'),
+    superUser: getEnvVar('ADMINS')
 } as const // readonly keys
 
 export default Keys

--- a/src/utils/jsonHandler.ts
+++ b/src/utils/jsonHandler.ts
@@ -4,7 +4,8 @@ export interface Configuration {
     readonly name: string
     options: {
         'message-stream'?: boolean,
-        'message-style'?: boolean
+        'message-style'?: boolean,
+        'toggle-chat'?: boolean
     }
 }
 


### PR DESCRIPTION
## Added
* Shutoff slash command only accessible to admin users specified in the environment file `.env`.
* `toggle-chat` has been implemented to work now when disabled, it will notify the user to reach out to admins to re-enable the discord bot if something happened.

## Notes
* Multiple admins can be set in the `.env` as a list/array of usernames of discord users. It would be nice to detect who are the admins in the server (essentially people who have **Administrator** roles in the servers to use the slash command rather than the environment file. Will probably create an issue for this.

![working-disable](https://github.com/kevinthedang/discord-ollama/assets/77701718/0d291db5-7e7b-47e3-8ad9-02a73721f382)
![image](https://github.com/kevinthedang/discord-ollama/assets/77701718/6757bfdf-c565-4e0c-a754-c06bbc030d99)

