### PR TITLE
Modify Capacity Command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: discord/bot:0.3.5
+    image: discord/bot:0.3.6
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       GUILD_ID: ${GUILD_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/commands/capacity.ts
+++ b/src/commands/capacity.ts
@@ -1,0 +1,33 @@
+import { ChannelType, Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
+import { SlashCommand } from '../utils/commands.js'
+import { openFile } from '../utils/jsonHandler.js'
+
+export const Capacity: SlashCommand = {
+    name: 'modify-capacity',
+    description: 'number of messages bot will hold for context.',
+
+    // set available user options to pass to the command
+    options: [
+        {
+            name: 'context-capacity',
+            description: 'a number to set capacity',
+            type: ApplicationCommandOptionType.Number,
+            required: true
+        }
+    ],
+
+    // Query for message information and set the style
+    run: async (client: Client, interaction: CommandInteraction) => {
+        // fetch channel and message
+        const channel = await client.channels.fetch(interaction.channelId)
+        if (!channel || channel.type !== ChannelType.GuildText) return
+
+        // set state of bot chat features
+        openFile('config.json', interaction.commandName, interaction.options.get('context-capacity')?.value)
+
+        interaction.reply({
+            content: `Message History Capacity has been set to \`${interaction.options.get('context-capacity')?.value}\``,
+            ephemeral: true
+        })
+    }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,11 +4,13 @@ import { MessageStyle } from './messageStyle.js'
 import { MessageStream } from './messageStream.js'
 import { Disable } from './disable.js'
 import { Shutoff } from './shutoff.js'
+import { Capacity } from './capacity.js'
 
 export default [
     ThreadCreate,
     MessageStyle,
     MessageStream,
     Disable,
-    Shutoff
+    Shutoff,
+    Capacity
 ] as SlashCommand[]

--- a/src/queues/queue.ts
+++ b/src/queues/queue.ts
@@ -17,7 +17,7 @@ export class Queue<T> implements IQueue<T> {
      * Set up Queue
      * @param capacity max length of queue
      */
-    constructor(private capacity: number = 5) {}
+    constructor(public capacity: number = 5) {}
 
     /**
      * Put item in front of queue
@@ -58,13 +58,5 @@ export class Queue<T> implements IQueue<T> {
      */
     getItems(): T[] {
         return this.storage
-    }
-
-    /**
-     * Get capacity of the queue
-     * @returns capacity of queue
-     */
-    getCapacity(): number {
-        return this.capacity
     }
 }

--- a/src/utils/jsonHandler.ts
+++ b/src/utils/jsonHandler.ts
@@ -5,7 +5,8 @@ export interface Configuration {
     options: {
         'message-stream'?: boolean,
         'message-style'?: boolean,
-        'toggle-chat'?: boolean
+        'toggle-chat'?: boolean,
+        'history-capacity'?: number
     }
 }
 


### PR DESCRIPTION
## Added
* Capacity Modify command found in `commands/capacity.ts`

## Notes
* Command will modify the context queue capacity to user specified number from slash command.
* Number parameter when running command is required to prevent undefined case.
* Default Capacity still set at 5, unless there is a gripe about it.

### Sample
![image](https://github.com/kevinthedang/discord-ollama/assets/77701718/01892a5f-9746-48e3-a052-4f85b009f861)
