### PR TITLE
Message Blocks for Normal Message Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The project aims to:
   * [ ] Message Persistance on Channels and Threads
   * [x] Containerization with Docker
   * [x] Slash Commands Compatible
-  * [ ] Generated Token Length Handling for >2000 or >6000 characters
+  * [x] Generated Token Length Handling for >2000 ~~or >6000 characters~~
   * [ ] External WebUI Integration
   * [ ] Administrator Role Compatible
 * [ ] Allow others to create their own models personalized for their own servers!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: discord/bot:0.3.6
+    image: discord/bot:0.4.0
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       GUILD_ID: ${GUILD_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.3.6",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/utils/messageNormal.ts
+++ b/src/utils/messageNormal.ts
@@ -21,7 +21,7 @@ export async function normalMessage(
     // bot's respnse
     let response: ChatResponse
 
-    await message.reply('Generating Response . . .').then(async sentMessage => {
+    await message.channel.send('Generating Response . . .').then(async sentMessage => {
         try {
             // Attempt to query model for message
             response = await ollama.chat({
@@ -35,9 +35,13 @@ export async function normalMessage(
                 },
                 stream: false
             })
-            
-            // edit the 'generic' response to new message
-            sentMessage.edit(response.message.content)
+
+            // check if message length > discord max for normal messages
+            if (response.message.content.length > 2000) {
+                sentMessage.edit(response.message.content.slice(0, 2000))
+                message.channel.send(response.message.content.slice(2000))
+            } else // edit the 'generic' response to new message
+                sentMessage.edit(response.message.content)            
         } catch(error: any) {
             console.log(`[Util: messageNormal] Error creating message: ${error.message}`)
             sentMessage.edit(`**Response generation failed.**\n\nReason: ${error.message}`)


### PR DESCRIPTION
## Added
* If statement to check if the message generated by an LLM exceeds 2000 characters. If so slice into different blocks and send separately.

## Removed
* The bot will no longer reply to messages on the "Non-Embed" message style. (Refer to image below)

## Notes
* If you computer is not beefy, the messages can show up separately rather than together.

![image](https://github.com/kevinthedang/discord-ollama/assets/77701718/fec41cf1-2476-4fcd-8ae7-dd65a2566b4f)
