### PR TITLE
Remove Bot User ID from Message Prompt

### DIFF
--- a/src/utils/mentionClean.ts
+++ b/src/utils/mentionClean.ts
@@ -1,0 +1,16 @@
+import Keys from "../keys.js"
+
+/**
+ * Clean up the bot user_id so it only has the prompt
+ * 
+ * Sample: <@CLIENT_ID> Hello
+ *  - we want to remove <@CLIENT_ID>
+ *  - replace function works well for this
+ * 
+ * @param message 
+ * @returns 
+ */
+export function clean(message: string): string {
+    const cleanedMessage: string = message.replace(`<@${Keys.clientUid}>`, '').trim()
+    return cleanedMessage
+}


### PR DESCRIPTION
## Fixes
* Bot `client-uid` not longer a part of a user prompt. This used to cause problems with hallucinations where the bot would not address the prompt because the message had "sensitive information" in it.
* Also prevents cases of the bot hallucinating for now reason.
* Possibly improves computation time because it removes unnecessary information that could confuse the model. 