### PR TITLE
Discord Administrator Role Permissions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,6 +22,3 @@ DISCORD_IP = IP_ADDRESS
 
 # subnet address, ex. 172.18.0.0 as we use /16.
 SUBNET_ADDRESS = ADDRESS
-
-# list of admins to handle admin commands for the bot, use single quotes
-ADMINS=['username1', 'username2', 'username3', ...]

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -4,7 +4,7 @@ import { openFile } from '../utils/jsonHandler.js'
 
 export const Disable: SlashCommand = {
     name: 'toggle-chat',
-    description: 'toggle all chat features, slash commands will still work.',
+    description: 'toggle all chat features, Adminstrator Only.',
 
     // set available user options to pass to the command
     options: [
@@ -21,6 +21,15 @@ export const Disable: SlashCommand = {
         // fetch channel and message
         const channel = await client.channels.fetch(interaction.channelId)
         if (!channel || channel.type !== ChannelType.GuildText) return
+
+        // check if runner is an admin
+        if (!interaction.memberPermissions?.has('Administrator')) {
+            interaction.reply({
+                content: `${interaction.commandName} is an Administrator Command.\n\nYou, ${interaction.member?.user.username}, are not an Administrator in this server.\nPlease contact an admin to use this command.`,
+                ephemeral: true
+            })
+            return
+        }
 
         // set state of bot chat features
         openFile('config.json', interaction.commandName, interaction.options.get('enabled')?.value)

--- a/src/commands/shutoff.ts
+++ b/src/commands/shutoff.ts
@@ -1,10 +1,9 @@
 import { ChannelType, Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
 import { SlashCommand } from '../utils/commands.js'
-import Keys from '../keys.js'
 
 export const Shutoff: SlashCommand = {
     name: 'shutoff',
-    description: 'shutdown the bot. You will need to manually bring it online again.',
+    description: 'shutdown the bot. You will need to manually bring it online again. Administrator Only.',
 
     // set available user options to pass to the command
     options: [
@@ -25,24 +24,22 @@ export const Shutoff: SlashCommand = {
         // log this, this will probably be improtant for logging who did this
         console.log(`User -> ${interaction.user.tag} attempting to shutdown ${client.user!!.tag}`)
 
-        // create list of superUsers based on string parse
-        const superUsers: string[] = JSON.parse(Keys.superUser.replace(/'/g, '"'))
-
         // check if admin or false on shutdown
-        if (interaction.user.tag !in superUsers) {
+        if (!interaction.memberPermissions?.has('Administrator')) {
             interaction.reply({
-                content: `Shutdown failed:\n\n${interaction.user.tag}, You do not have permission to shutoff **${client.user?.tag}**.`,
+                content: `**Shutdown Aborted:**\n\n${interaction.user.tag}, You do not have permission to shutoff **${client.user?.tag}**.`,
                 ephemeral: true
             })
             return // stop from shutting down
         } else if (!interaction.options.get('are-you-sure')?.value) {
             interaction.reply({
-                content: `Shutdown failed:\n\n${interaction.user.tag}, You didn't want to shutoff **${client.user?.tag}**.`,
+                content: `**Shutdown Aborted:**\n\n${interaction.user.tag}, You didn't want to shutoff **${client.user?.tag}**.`,
                 ephemeral: true
             })
-            return
+            return // chickened out
         }
 
+        // Shutoff cleared, do it
         interaction.reply({
             content: `${client.user?.tag} is ${interaction.options.get('are-you-sure')?.value ?  "shutting down now." : "not shutting down." }`,
             ephemeral: true

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -8,7 +8,6 @@ export const Keys = {
     guildId: getEnvVar('GUILD_ID'),
     ipAddress: getEnvVar('OLLAMA_IP'),
     portAddress: getEnvVar('OLLAMA_PORT'),
-    superUser: getEnvVar('ADMINS')
 } as const // readonly keys
 
 export default Keys


### PR DESCRIPTION
## Added
* `Administrator` permission checks to `/toggle-chat` and `/shutoff`

## Updates
* Removed `superUser` (aka `ADMINS`) as an environment variable. Now it will be based on Client-side permissions set by the Discord server. 