### PR TITLE
Infinite Message Length for Block Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The project aims to:
   * [x] Containerization with Docker
   * [x] Slash Commands Compatible
   * [x] Generated Token Length Handling for >2000 ~~or >6000 characters~~
-    * [ ] Token Length Handling of any message size
+    * [x] Token Length Handling of any message size
   * [ ] External WebUI Integration
-  * [ ] Administrator Role Compatible
+  * [x] Administrator Role Compatible
 * [ ] Allow others to create their own models personalized for their own servers!
   * [ ] Documentation on creating your own LLM
   * [ ] Documentation on web scrapping and cleaning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: discord/bot:0.4.3
+    image: discord/bot:0.4.4
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       GUILD_ID: ${GUILD_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/utils/messageEmbed.ts
+++ b/src/utils/messageEmbed.ts
@@ -48,7 +48,7 @@ export async function embedMessage(
                 result += portion.message.content
 
                 // exceeds handled length
-                if (result.length > 6000) {
+                if (result.length > 5000) {
                     const errorEmbed = new EmbedBuilder()
                     .setTitle(`Responding to ${message.author.tag}`)
                     .setDescription(`Response length ${result.length} has exceeded Discord maximum.\n\nLong Stream messages not supported.`)
@@ -73,27 +73,27 @@ export async function embedMessage(
             result = response.message.content
 
             // long message, split into different embeds sadly.
-            if (result.length > 6000) {
+            if (result.length > 5000) {
                 const firstEmbed = new EmbedBuilder()
                 .setTitle(`Responding to ${message.author.tag}`)
-                .setDescription(result.slice(0, 6000) || 'No Content to Provide...')
+                .setDescription(result.slice(0, 5000) || 'No Content to Provide...')
                 .setColor('#00FF00')
 
                 // replace first embed
                 sentMessage.edit({ embeds: [firstEmbed] })
 
                 // take the rest out
-                result = result.slice(6000)
+                result = result.slice(5000)
 
                 // handle the rest
-                while (result.length > 6000) {
+                while (result.length > 5000) {
                     const whileEmbed = new EmbedBuilder()
                     .setTitle(`Responding to ${message.author.tag}`)
-                    .setDescription(result.slice(0, 6000) || 'No Content to Provide...')
+                    .setDescription(result.slice(0, 5000) || 'No Content to Provide...')
                     .setColor('#00FF00')
 
                     message.channel.send({ embeds: [whileEmbed] })
-                    result = result.slice(6000)
+                    result = result.slice(5000)
                 }
 
                 const lastEmbed = new EmbedBuilder()

--- a/src/utils/messageEmbed.ts
+++ b/src/utils/messageEmbed.ts
@@ -51,7 +51,7 @@ export async function embedMessage(
                 if (result.length > 6000) {
                     const errorEmbed = new EmbedBuilder()
                     .setTitle(`Responding to ${message.author.tag}`)
-                    .setDescription(result || 'No Content Yet...')
+                    .setDescription(`Response length ${result.length} has exceeded Discord maximum.\n\nLong Stream messages not supported.`)
                     .setColor('#00FF00')
 
                     // send error

--- a/src/utils/messageNormal.ts
+++ b/src/utils/messageNormal.ts
@@ -49,8 +49,17 @@ export async function normalMessage(
                 // check if message length > discord max for normal messages
                 if (result.length > 2000) {
                     sentMessage.edit(result.slice(0, 2000))
-                    message.channel.send(result.slice(2000))
-                } else // edit the 'generic' response to new message
+                    result = result.slice(2000)
+
+                    // handle for rest of message that is >2000
+                    while (result.length > 2000) {
+                        message.channel.send(result.slice(0, 2000))
+                        result = result.slice(2000)
+                    }
+
+                    // last part of message
+                    message.channel.send(result)
+                } else // edit the 'generic' response to new message since <2000
                     sentMessage.edit(result)
             }            
         } catch(error: any) {
@@ -59,6 +68,6 @@ export async function normalMessage(
         }
     })
 
-    // return the string representation of response
+    // return the string representation of ollama query response
     return result
 }

--- a/src/utils/messageNormal.ts
+++ b/src/utils/messageNormal.ts
@@ -2,7 +2,6 @@ import { Message } from 'discord.js'
 import { ChatResponse, Ollama } from 'ollama'
 import { ChatParams, UserMessage, streamResponse, blockResponse } from './index.js'
 import { Queue } from '../queues/queue.js'
-import { channel } from 'diagnostics_channel'
 
 /**
  * Method to send replies as normal text on discord like any other user

--- a/src/utils/messageNormal.ts
+++ b/src/utils/messageNormal.ts
@@ -2,6 +2,7 @@ import { Message } from 'discord.js'
 import { ChatResponse, Ollama } from 'ollama'
 import { ChatParams, UserMessage, streamResponse, blockResponse } from './index.js'
 import { Queue } from '../queues/queue.js'
+import { channel } from 'diagnostics_channel'
 
 /**
  * Method to send replies as normal text on discord like any other user
@@ -37,6 +38,12 @@ export async function normalMessage(
                 for await (const portion of response) {
                     // append token to message
                     result += portion.message.content
+
+                    // exceeds handled length
+                    if (result.length > 2000) {
+                        message.channel.send(`Response length ${result.length} has exceeded Discord maximum.\n\nLong Stream messages not supported.`)
+                        break // stop stream
+                    }
 
                     // resent current output, THIS WILL BE SLOW due to discord limits!
                     sentMessage.edit(result || 'No Content Yet...')


### PR DESCRIPTION
## Added
* Infinite message generation for block messages on both embeds and normal messages.
* Errors will now appear in the chat when the stream message length exceeds Discord's max length per style.

## Notes
* Message streaming currently does not have this and will probably be implemented later.
* Embed lengths will change based on if other features are added to the embeds.