### PR TITLE
Removed Ollama API Threads as an Option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Builds
 run-name: Validate Node and Docker Builds
 on:
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 run-name: Unit Tests
 on:
-  push:
+  pull_request:
     branches:
       - master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: Test source code for errors
+run-name: Unit Tests
 on:
   push:
     branches:

--- a/src/utils/streamHandler.ts
+++ b/src/utils/streamHandler.ts
@@ -11,7 +11,6 @@ export async function streamResponse(params: ChatParams): Promise<AsyncGenerator
         model: params.model,
         messages: params.msgHist,
         options: {
-            num_thread: 8, // remove if optimization needed further
             mirostat: 1,
             mirostat_tau: 2.0,
             top_k: 70
@@ -30,7 +29,6 @@ export async function blockResponse(params: ChatParams): Promise<ChatResponse> {
         model: params.model,
         messages: params.msgHist,
         options: {
-            num_thread: 8, // remove if optimization needed further
             mirostat: 1,
             mirostat_tau: 2.0,
             top_k: 70


### PR DESCRIPTION
## Removed
* Threads as an option for the `/chat` API endpoint from ollama. This should allow ollama/the system to decide how many threads it should utilize.

## Fixes
* The workflows "dispatched" at the incorrect instances. That is now fixed as Unit Tests should be ran in PRs prior to merging to validate incoming code.