### PR TITLE
Infinite Message Length for Streamed Messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: discord/bot:0.5.0
+    image: discord/bot:0.5.1
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       GUILD_ID: ${GUILD_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",


### PR DESCRIPTION
## Changes
* Allows for streamed messages to go on forever to account for other models that might produce very large response from a prompt (I'm looking at you Mistral).

## Note
* It's important to remember that streaming is very slow on Discord because of how **discord limits how many messages can occur every 5 seconds** (or what seems to be like a little over 5 seconds).