### PR TITLE
User vs Server Preferences

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - master
     paths:
       - '/'
+      - 'src/**'
+      - 'tests/**'
       - '!docs/**'
       - '!imgs/**'
       - '!.github/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - master
     paths:
       - '/'
+      - 'src/**'
+      - 'tests/**'
       - '!docs/**'
       - '!imgs/**'
       - '!.github/**'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: discord/bot:0.5.2
+    image: discord/bot:0.5.4
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       GUILD_ID: ${GUILD_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.5.2",
+      "version": "0.5.4",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/commands/capacity.ts
+++ b/src/commands/capacity.ts
@@ -23,7 +23,7 @@ export const Capacity: SlashCommand = {
         if (!channel || channel.type !== (ChannelType.PublicThread && ChannelType.GuildText)) return
 
         // set state of bot chat features
-        openConfig('config.json', interaction.commandName, interaction.options.get('context-capacity')?.value)
+        openConfig(`${interaction.client.user.username}-config.json`, interaction.commandName, interaction.options.get('context-capacity')?.value)
 
         interaction.reply({
             content: `Message History Capacity has been set to \`${interaction.options.get('context-capacity')?.value}\``,

--- a/src/commands/channelToggle.ts
+++ b/src/commands/channelToggle.ts
@@ -24,7 +24,7 @@ export const ChannelToggle: SlashCommand = {
 
 
         // set state of bot channel preferences
-        openConfig(`${interaction.channel?.id}-config.json`, interaction.commandName, interaction.options.get('toggle-channel')?.value)
+        openConfig(`${interaction.guildId}-config.json`, interaction.commandName, interaction.options.get('toggle-channel')?.value)
 
         interaction.reply({
             content: `Channel Preferences have for Regular Channels set to \`${interaction.options.get('toggle-channel')?.value}\``,

--- a/src/commands/channelToggle.ts
+++ b/src/commands/channelToggle.ts
@@ -24,7 +24,7 @@ export const ChannelToggle: SlashCommand = {
 
 
         // set state of bot channel preferences
-        openConfig('config.json', interaction.commandName, interaction.options.get('toggle-channel')?.value)
+        openConfig(`${interaction.channel?.id}-config.json`, interaction.commandName, interaction.options.get('toggle-channel')?.value)
 
         interaction.reply({
             content: `Channel Preferences have for Regular Channels set to \`${interaction.options.get('toggle-channel')?.value}\``,

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -32,7 +32,7 @@ export const Disable: SlashCommand = {
         }
 
         // set state of bot chat features
-        openConfig('config.json', interaction.commandName, interaction.options.get('enabled')?.value)
+        openConfig(`${interaction.channel?.id}-config.json`, interaction.commandName, interaction.options.get('enabled')?.value)
 
         interaction.reply({
             content: `Chat features has been \`${interaction.options.get('enabled')?.value ?  "enabled" : "disabled" }\``,

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -32,7 +32,7 @@ export const Disable: SlashCommand = {
         }
 
         // set state of bot chat features
-        openConfig(`${interaction.channel?.id}-config.json`, interaction.commandName, interaction.options.get('enabled')?.value)
+        openConfig(`${interaction.guildId}-config.json`, interaction.commandName, interaction.options.get('enabled')?.value)
 
         interaction.reply({
             content: `Chat features has been \`${interaction.options.get('enabled')?.value ?  "enabled" : "disabled" }\``,

--- a/src/commands/messageStream.ts
+++ b/src/commands/messageStream.ts
@@ -23,7 +23,7 @@ export const MessageStream: SlashCommand = {
         if (!channel || channel.type !== (ChannelType.PublicThread && ChannelType.GuildText)) return
 
         // save value to json and write to it
-        openConfig('config.json', interaction.commandName, interaction.options.get('stream')?.value)
+        openConfig(`${interaction.client.user.username}-config.json`, interaction.commandName, interaction.options.get('stream')?.value)
 
         interaction.reply({
             content: `Message streaming preferences set to: \`${interaction.options.get('stream')?.value}\``,

--- a/src/commands/messageStyle.ts
+++ b/src/commands/messageStyle.ts
@@ -23,7 +23,7 @@ export const MessageStyle: SlashCommand = {
         if (!channel || channel.type !== (ChannelType.PublicThread && ChannelType.GuildText)) return
 
         // set the message style
-        openConfig('config.json', interaction.commandName, interaction.options.get('embed')?.value)
+        openConfig(`${interaction.client.user.username}-config.json`, interaction.commandName, interaction.options.get('embed')?.value)
 
         interaction.reply({
             content: `Message style preferences for embed set to: \`${interaction.options.get('embed')?.value}\``,

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -5,6 +5,8 @@ import { TextChannel, ThreadChannel } from 'discord.js'
 
 /** 
  * Max Message length for free users is 2000 characters (bot or not).
+ * Bot supports infinite lengths for normal messages.
+ * 
  * @param message the message received from the channel
  */
 export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama, client }, message) => {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,5 +1,5 @@
 import { embedMessage, event, Events, normalMessage, UserMessage } from '../utils/index.js'
-import { Configuration, getChannelInfo, getConfig, getThread, openChannelInfo, openConfig, openThreadInfo } from '../utils/jsonHandler.js'
+import { getChannelInfo, getServerConfig, getThread, getUserConfig, openChannelInfo, openConfig, openThreadInfo, ServerConfig, UserConfig } from '../utils/jsonHandler.js'
 import { clean } from '../utils/mentionClean.js'
 import { TextChannel, ThreadChannel } from 'discord.js'
 
@@ -11,20 +11,26 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
     log(`Message \"${clean(message.content)}\" from ${message.author.tag} in channel/thread ${message.channelId}.`)
 
     // Do not respond if bot talks in the chat
-    if (message.author.tag === message.client.user.tag) return
+    if (message.author.username === message.client.user.username) return
 
     // Only respond if message mentions the bot
     if (!message.mentions.has(tokens.clientUid)) return
 
+    // default stream to false
     let shouldStream = false
-
-    // Try to query and send embed     
+ 
     try {
-        const config: Configuration = await new Promise((resolve, reject) => {
-            getConfig('config.json', (config) => {
+        // Retrieve Server/Guild Preferences
+        const serverConfig: ServerConfig = await new Promise((resolve, reject) => {
+            getServerConfig(`${message.guildId}-config.json`, (config) => {
                 // check if config.json exists
                 if (config === undefined) {
-                    reject(new Error('No Configuration is set up.\n\nCreating \`config.json\` with \`message-style\` set as \`false\` for regular messages.\nPlease try chatting again.'))
+                    // Allowing chat options to be available
+                    openConfig(`${message.guildId}-config.json`, 'toggle-chat', true)
+
+                    // default to channel scope chats
+                    openConfig(`${message.guildId}-config.json`, 'channel-toggle', true)
+                    reject(new Error('No Server Preferences is set up.\n\nCreating default server preferences file...\nPlease try chatting again.'))
                     return
                 }
 
@@ -38,10 +44,23 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
                 if (config.options['channel-toggle']) {
                     openChannelInfo(message.channelId,
                         message.channel as TextChannel, 
-                        message.author.tag
+                        message.author.username
                     )
                 }
 
+                resolve(config)
+            })
+        })
+
+        // Retrieve User Preferences
+        const userConfig: UserConfig = await new Promise((resolve, reject) => {
+            getUserConfig(`${message.author.username}-config.json`, (config) => {
+                if (config === undefined) {
+                    openConfig(`${message.author.username}-config.json`, 'message-style', false)
+                    reject(new Error('No User Preferences is set up.\n\nCreating preferences file with \`message-style\` set as \`false\` for regular messages.\nPlease try chatting again.'))
+                    return
+                }
+    
                 // check if there is a set capacity in config
                 if (typeof config.options['modify-capacity'] !== 'number')
                     log(`Capacity is undefined, using default capacity of ${msgHist.capacity}.`)
@@ -51,23 +70,25 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
                     log(`New Capacity found. Setting Context Capacity to ${config.options['modify-capacity']}.`)
                     msgHist.capacity = config.options['modify-capacity']
                 }
-
+    
                 // set stream state
                 shouldStream = config.options['message-stream'] as boolean || false
-
+    
                 resolve(config)
             })
         })
 
+        
+
         // need new check for "open/active" threads/channels here!
         const chatMessages: UserMessage[] = await new Promise((resolve) => {
             // set new queue to modify
-            if (config.options['channel-toggle']) {
-                getChannelInfo(`${message.channelId}-${message.author.tag}.json`, (channelInfo) => {
+            if (serverConfig.options['channel-toggle']) {
+                getChannelInfo(`${message.channelId}-${message.author.username}.json`, (channelInfo) => {
                     if (channelInfo?.messages)
                         resolve(channelInfo.messages)
                     else
-                        log(`Channel ${message.channel}-${message.author.tag} does not exist.`)
+                        log(`Channel ${message.channel}-${message.author.username} does not exist.`)
                 })
             } else {
                 getThread(`${message.channelId}.json`, (threadInfo) => {
@@ -95,7 +116,7 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
         })
         
         // undefined or false, use normal, otherwise use embed
-        if (config.options['message-style'])
+        if (userConfig.options['message-style'])
             response = await embedMessage(message, ollama, tokens, msgHist, shouldStream)
         else
             response = await normalMessage(message, ollama, tokens, msgHist, shouldStream)
@@ -113,7 +134,7 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
         })
 
         // only update the json on success
-        if (config.options['channel-toggle']) {
+        if (serverConfig.options['channel-toggle']) {
             openChannelInfo(message.channelId, 
                 message.channel as TextChannel, 
                 message.author.tag, 
@@ -127,7 +148,6 @@ export default event(Events.MessageCreate, async ({ log, msgHist, tokens, ollama
         }
     } catch (error: any) {
         msgHist.pop() // remove message because of failure
-        openConfig('config.json', 'message-style', false)
         message.reply(`**Error Occurred:**\n\n**Reason:** *${error.message}*`)
     }
 })


### PR DESCRIPTION
## Changes
* When calling "server-like" commands, they will create a file for that server.
* When talking to the bot, it will create a file for user settings specific to that user's name.
* Separated Server Prefs from User Prefs from being 1 file. Nice.

## Notes
* It can be a bit annoying when first setting up the bot, but it really is not so bad.
  * Talking to the bot 1st time -> creates Server preferences if they do not exist
  * Talking to the bot 2nd time -> creates User preferences if the user does not have any.

## Screenshot
* First file is the Server's configuration.
* The next 2 files are channel histories designated to a user.
* The last 2 files are user configurations.

![image](https://github.com/kevinthedang/discord-ollama/assets/77701718/517366db-a0c5-41f9-b48f-3b0321fbae4f)
