### PR TITLE
Clear User Channel History Command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: discord/bot:0.5.5
+    image: discord/bot:0.5.6
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       GUILD_ID: ${GUILD_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/commands/cleanUserChannelHistory.ts
+++ b/src/commands/cleanUserChannelHistory.ts
@@ -1,0 +1,27 @@
+import { ChannelType, Client, CommandInteraction, TextChannel } from 'discord.js'
+import { SlashCommand } from '../utils/commands.js'
+import { clearChannelInfo } from '../utils/index.js'
+
+export const ClearUserChannelHistory: SlashCommand = {
+    name: 'clear-user-channel-history',
+    description: 'clears history for user running this command in current channel',
+
+    // Clear channel history for intended user
+    run: async (client: Client, interaction: CommandInteraction) => {
+        // fetch current channel
+        const channel = await client.channels.fetch(interaction.channelId)
+
+        // if not an existing channel or a GuildText, fail command
+        if (!channel || channel.type !== ChannelType.GuildText) return
+
+        // clear channel info for user
+        await clearChannelInfo(interaction.channelId, 
+            interaction.channel as TextChannel, 
+            interaction.user.username)
+        
+        interaction.reply({
+            content: `Channel history in ${channel.name} cleared for ${interaction.user.username}`,
+            ephemeral: true
+        })
+    }
+}

--- a/src/commands/cleanUserChannelHistory.ts
+++ b/src/commands/cleanUserChannelHistory.ts
@@ -15,13 +15,18 @@ export const ClearUserChannelHistory: SlashCommand = {
         if (!channel || channel.type !== ChannelType.GuildText) return
 
         // clear channel info for user
-        await clearChannelInfo(interaction.channelId, 
+        const successfulWipe = await clearChannelInfo(interaction.channelId, 
             interaction.channel as TextChannel, 
             interaction.user.username)
-        
-        interaction.reply({
-            content: `Channel history in ${channel.name} cleared for ${interaction.user.username}`,
-            ephemeral: true
-        })
+        if (successfulWipe)
+            interaction.reply({ 
+                content: `Channel history in **${channel.name}** cleared for **${interaction.user.username}**.`, 
+                ephemeral: true
+            })
+        else
+            interaction.reply({ 
+                content: `Channel history could not be found for **${interaction.user.username}** in **${channel.name}**.\n\nPlease chat with **${client.user?.username}** to start a chat history.`, 
+                ephemeral: true
+            })
     }
 }

--- a/src/commands/cleanUserChannelHistory.ts
+++ b/src/commands/cleanUserChannelHistory.ts
@@ -18,6 +18,8 @@ export const ClearUserChannelHistory: SlashCommand = {
         const successfulWipe = await clearChannelInfo(interaction.channelId, 
             interaction.channel as TextChannel, 
             interaction.user.username)
+
+        // check result of clearing history
         if (successfulWipe)
             interaction.reply({ 
                 content: `Channel history in **${channel.name}** cleared for **${interaction.user.username}**.`, 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import { Shutoff } from './shutoff.js'
 import { Capacity } from './capacity.js'
 import { PrivateThreadCreate } from './threadPrivateCreate.js'
 import { ChannelToggle } from './channelToggle.js'
+import { ClearUserChannelHistory } from './cleanUserChannelHistory.js'
 
 export default [
     ThreadCreate,
@@ -16,5 +17,6 @@ export default [
     Disable,
     Shutoff,
     Capacity,
-    ChannelToggle
+    ChannelToggle,
+    ClearUserChannelHistory
 ] as SlashCommand[]

--- a/src/commands/threadCreate.ts
+++ b/src/commands/threadCreate.ts
@@ -19,7 +19,7 @@ export const ThreadCreate: SlashCommand = {
         })
 
         // Send a message in the thread
-        thread.send(`Hello ${interaction.user} and others! \n\nIt's nice to meet you. Please talk to me by typing **@${client.user?.username}** with your prompt.`)
+        thread.send(`Hello ${interaction.user} and others! \n\nIt's nice to meet you. Please talk to me by typing **@${client.user?.username}** with your prompt.\n\nIf I do not respond, ensure \`channel-toggle\` is set to \`false\``)
 
         // handle storing this chat channel
         // store: thread.id, thread.name

--- a/src/utils/handlers/chatHistoryHandler.ts
+++ b/src/utils/handlers/chatHistoryHandler.ts
@@ -67,8 +67,8 @@ export async function getThread(filename: string, callback: (config: Thread | un
 async function checkChannelInfoExists(channel: TextChannel, user: string) {
     // thread exist handler
     const isThread: boolean = await new Promise((resolve) => {
-        getThread(`${channel.id}-${user}.json`, (threadInfo) => {
-            if (threadInfo?.messages)
+        getThread(`${channel.id}-${user}.json`, (channelInfo) => {
+            if (channelInfo?.messages)
                 resolve(true)
             else
                 resolve(false)
@@ -122,6 +122,18 @@ export async function clearChannelInfo(filename: string, channel: TextChannel, u
  * @param messages their messages
  */
 export async function openChannelInfo(filename: string, channel: TextChannel, user: string, messages: UserMessage[] = []): Promise<void> {
+    const isThread: boolean = await new Promise((resolve) => {
+        getThread(`${channel.id}.json`, (threadInfo) => {
+            if (threadInfo?.messages)
+                resolve(true)
+            else
+                resolve(false)
+        })
+    })
+
+    // this is a thread channel, do not duplicate files
+    if (isThread) return
+
     const fullFileName = `data/${filename}-${user}.json`
     if (fs.existsSync(fullFileName)) {
         fs.readFile(fullFileName, 'utf8', (error, data) => {

--- a/src/utils/handlers/chatHistoryHandler.ts
+++ b/src/utils/handlers/chatHistoryHandler.ts
@@ -85,22 +85,32 @@ async function checkChannelInfoExists(channel: TextChannel, user: string) {
  * @param user username of user
  * @returns nothing
  */
-export async function clearChannelInfo(filename: string, channel: TextChannel, user: string): Promise<void> {
+export async function clearChannelInfo(filename: string, channel: TextChannel, user: string): Promise<boolean> {
     const channelInfoExists: boolean = await checkChannelInfoExists(channel, user)
 
     // If thread does not exist, file can't be found
-    if (!channelInfoExists) return
+    if (!channelInfoExists) return false
 
+    // Attempt to clear user channel history
     const fullFileName = `data/${filename}-${user}.json`
-    fs.readFile(fullFileName, 'utf8', (error, data) => {
-        if (error)
-            console.log(`[Error: openChannelInfo] Incorrect file format`)
-        else {
-            const object = JSON.parse(data)
-            object['messages'] =  [] // cleared history
-            fs.writeFileSync(fullFileName, JSON.stringify(object, null, 2))
-        }
+    const cleanedHistory: boolean = await new Promise((resolve) => {
+        fs.readFile(fullFileName, 'utf8', (error, data) => {
+            if (error)
+                console.log(`[Error: openChannelInfo] Incorrect file format`)
+            else {
+                const object = JSON.parse(data)
+                if (object['messages'].length === 0) // already empty, let user know
+                    resolve(false)
+                else {
+                    object['messages'] = [] // cleared history
+                    fs.writeFileSync(fullFileName, JSON.stringify(object, null, 2))
+                    resolve(true)
+                }
+            }
+        })
     })
+    console.log(cleanedHistory)
+    return cleanedHistory
 }
 
 /**

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -22,6 +22,6 @@ describe('#commands', () => {
     // test specific commands in the object
     it('references specific commands', () => {
         const commandsString = commands.map(e => e.name).join(', ')
-        expect(commandsString).toBe('thread, private-thread, message-style, message-stream, toggle-chat, shutoff, modify-capacity, channel-toggle')
+        expect(commandsString).toBe('thread, private-thread, message-style, message-stream, toggle-chat, shutoff, modify-capacity, channel-toggle, clear-user-channel-history')
     })
 })


### PR DESCRIPTION
## Changes
* Added `clear-user-channel-history` Slash Command to clear chat history in the current `GuildText` Channel for a user.
* Added bot replies to tell user if chat history was cleared or doesn't exist (or is already empty).
* Clarified comment for thread existing while `channel-toggle` was `true`, do not create duplicate history files.

