### PR TITLE
Pull and Switch Model Revised

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: kevinthedang/discord-ollama:0.7.2
+    image: kevinthedang/discord-ollama:0.7.3
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       OLLAMA_IP: ${OLLAMA_IP}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/commands/capacity.ts
+++ b/src/commands/capacity.ts
@@ -3,13 +3,13 @@ import { openConfig, SlashCommand, UserCommand } from '../utils/index.js'
 
 export const Capacity: SlashCommand = {
     name: 'modify-capacity',
-    description: 'number of messages bot will hold for context.',
+    description: 'maximum amount messages bot will hold for context.',
 
     // set available user options to pass to the command
     options: [
         {
             name: 'context-capacity',
-            description: 'a number to set capacity',
+            description: 'number of allowed messages to remember',
             type: ApplicationCommandOptionType.Number,
             required: true
         }
@@ -25,7 +25,7 @@ export const Capacity: SlashCommand = {
         openConfig(`${interaction.user.username}-config.json`, interaction.commandName, interaction.options.get('context-capacity')?.value)
 
         interaction.reply({
-            content: `Message History Capacity has been set to \`${interaction.options.get('context-capacity')?.value}\``,
+            content: `Max message history is now set to \`${interaction.options.get('context-capacity')?.value}\``,
             ephemeral: true
         })
     }

--- a/src/commands/cleanUserChannelHistory.ts
+++ b/src/commands/cleanUserChannelHistory.ts
@@ -3,7 +3,7 @@ import { clearChannelInfo, SlashCommand, UserCommand } from '../utils/index.js'
 
 export const ClearUserChannelHistory: SlashCommand = {
     name: 'clear-user-channel-history',
-    description: 'clears history for user running this command in current channel',
+    description: 'clears history for user in the current channel',
 
     // Clear channel history for intended user
     run: async (client: Client, interaction: CommandInteraction) => {
@@ -21,12 +21,12 @@ export const ClearUserChannelHistory: SlashCommand = {
         // check result of clearing history
         if (successfulWipe)
             interaction.reply({ 
-                content: `Channel history in **this channel** successfully cleared for **${interaction.user.username}**.`, 
+                content: `History cleared in **this channel** cleared for **${interaction.user.username}**.`, 
                 ephemeral: true
             })
         else
             interaction.reply({ 
-                content: `Channel history could not be found for **${interaction.user.username}** in **this channel**.\n\nPlease chat with **${client.user?.username}** to start a chat history.`, 
+                content: `History was not be found for **${interaction.user.username}** in **this channel**.\n\nPlease chat with **${client.user?.username}** to start a chat history.`, 
                 ephemeral: true
             })
     }

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -1,9 +1,9 @@
-import { ChannelType, Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
+import { Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
 import { AdminCommand, openConfig, SlashCommand } from '../utils/index.js'
 
 export const Disable: SlashCommand = {
     name: 'toggle-chat',
-    description: 'toggle all chat features, Adminstrator Only.',
+    description: 'toggle all chat features. Adminstrator Only.',
 
     // set available user options to pass to the command
     options: [
@@ -24,7 +24,7 @@ export const Disable: SlashCommand = {
         // check if runner is an admin
         if (!interaction.memberPermissions?.has('Administrator')) {
             interaction.reply({
-                content: `${interaction.commandName} is an Administrator Command.\n\nYou, ${interaction.member?.user.username}, are not an Administrator in this server.\nPlease contact an admin to use this command.`,
+                content: `${interaction.commandName} is an admin command.\n\nPlease contact an admin to use this command for you.`,
                 ephemeral: true
             })
             return
@@ -34,7 +34,7 @@ export const Disable: SlashCommand = {
         openConfig(`${interaction.guildId}-config.json`, interaction.commandName, interaction.options.get('enabled')?.value)
 
         interaction.reply({
-            content: `Chat features has been \`${interaction.options.get('enabled')?.value ?  "enabled" : "disabled" }\``,
+            content: `${client.user?.username} is now **${interaction.options.get('enabled')?.value ?  "enabled" : "disabled" }**.`,
             ephemeral: true
         })
     }

--- a/src/commands/messageStream.ts
+++ b/src/commands/messageStream.ts
@@ -3,13 +3,13 @@ import { openConfig, SlashCommand, UserCommand } from '../utils/index.js'
 
 export const MessageStream: SlashCommand = {
     name: 'message-stream',
-    description: 'change preference on message streaming from ollama. WARNING: can be very slow.',
+    description: 'change preference on message streaming from ollama. WARNING: can be very slow due to Discord limits.',
 
     // user option(s) for setting stream
     options: [
         {
             name: 'stream',
-            description: 'enable or disable stream preference',
+            description: 'enable or disable message streaming',
             type: ApplicationCommandOptionType.Boolean,
             required: true
         }
@@ -25,7 +25,7 @@ export const MessageStream: SlashCommand = {
         openConfig(`${interaction.user.username}-config.json`, interaction.commandName, interaction.options.get('stream')?.value)
 
         interaction.reply({
-            content: `Message streaming preferences set to: \`${interaction.options.get('stream')?.value}\``,
+            content: `Message streaming is now set to: \`${interaction.options.get('stream')?.value}\``,
             ephemeral: true
         })
     }

--- a/src/commands/pullModel.ts
+++ b/src/commands/pullModel.ts
@@ -6,7 +6,7 @@ import { UserCommand } from "../utils/index.js";
 
 export const PullModel: SlashCommand = {
     name: 'pull-model',
-    description: 'pulls a model from the ollama model library',
+    description: 'pulls a model from the ollama model library. Administrator Only',
 
     // set available user options to pass to the command
     options: [
@@ -31,7 +31,7 @@ export const PullModel: SlashCommand = {
         // Admin Command
         if (!interaction.memberPermissions?.has('Administrator')) {
             interaction.reply({
-                content: `${interaction.commandName} is an Administrator Command.\n\nYou, ${interaction.member?.user.username}, are not an Administrator in this server.\nPlease contact an admin to use this command.`,
+                content: `${interaction.commandName} is an admin command.\n\nPlease contact a server admin to pull the model you want.`,
                 ephemeral: true
             })
             return
@@ -43,12 +43,16 @@ export const PullModel: SlashCommand = {
 
         try {
             // call ollama to pull desired model
-            if (!modelExists)
+            if (!modelExists) {
+                interaction.editReply({
+                    content: `**${modelInput}** could not be found. Please wait patiently as I try to retrieve it...`
+                })
                 await ollama.pull({ model: modelInput })
+            }
         } catch (error) {
             // could not resolve pull or model unfound
             interaction.editReply({
-                content: `Could not pull/locate the **${modelInput}** model within the [Ollama Model Library](https://ollama.com/library).\n\nPlease check the model library and try again.`
+                content: `Could not retrieve the **${modelInput}** model. You can find models at [Ollama Model Library](https://ollama.com/library).\n\nPlease check the model library and try again.`
             })
             return
         }
@@ -56,11 +60,11 @@ export const PullModel: SlashCommand = {
         // successful interaction
         if (modelExists)
             interaction.editReply({
-                content: `**${modelInput}** is already in your local model library.`
+                content: `**${modelInput}** is already available.`
             })
         else
             interaction.editReply({
-                content: `Successfully added **${modelInput}** into your local model library.`
+                content: `Successfully added **${modelInput}**.`
             })
     }
 }

--- a/src/commands/pullModel.ts
+++ b/src/commands/pullModel.ts
@@ -28,6 +28,15 @@ export const PullModel: SlashCommand = {
         const channel = await client.channels.fetch(interaction.channelId)
         if (!channel || !UserCommand.includes(channel.type)) return
 
+        // Admin Command
+        if (!interaction.memberPermissions?.has('Administrator')) {
+            interaction.reply({
+                content: `${interaction.commandName} is an Administrator Command.\n\nYou, ${interaction.member?.user.username}, are not an Administrator in this server.\nPlease contact an admin to use this command.`,
+                ephemeral: true
+            })
+            return
+        }
+
         // check if model was already pulled
         const modelExists: boolean = await ollama.list()
             .then(response => response.models.some((model: ModelResponse) => model.name.startsWith(modelInput)))

--- a/src/commands/shutoff.ts
+++ b/src/commands/shutoff.ts
@@ -6,16 +6,6 @@ export const Shutoff: SlashCommand = {
     name: 'shutoff',
     description: 'shutdown the bot. You will need to manually bring it online again. Administrator Only.',
 
-    // set available user options to pass to the command
-    options: [
-        {
-            name: 'are-you-sure',
-            description: 'true = yes, false = I\'m scared',
-            type: ApplicationCommandOptionType.Boolean,
-            required: true
-        }
-    ],
-
     // Query for message information and set the style
     run: async (client: Client, interaction: CommandInteraction) => {
         // fetch channel and message
@@ -23,7 +13,7 @@ export const Shutoff: SlashCommand = {
         if (!channel || !AdminCommand.includes(channel.type)) return
 
         // log this, this will probably be improtant for logging who did this
-        console.log(`User -> ${interaction.user.tag} attempting to shutdown ${client.user!!.tag}`)
+        console.log(`[Command: shutoff] User ${interaction.user.tag} attempting to shutdown ${client.user!!.tag}`)
 
         // check if admin or false on shutdown
         if (!interaction.memberPermissions?.has('Administrator')) {
@@ -32,19 +22,14 @@ export const Shutoff: SlashCommand = {
                 ephemeral: true
             })
             return // stop from shutting down
-        } else if (!interaction.options.get('are-you-sure')?.value) {
-            interaction.reply({
-                content: `**Shutdown Aborted:**\n\n${interaction.user.tag}, You didn't want to shutoff **${client.user?.tag}**.`,
-                ephemeral: true
-            })
-            return // chickened out
         }
 
         // Shutoff cleared, do it
         interaction.reply({
-            content: `${client.user?.tag} is ${interaction.options.get('are-you-sure')?.value ?  "shutting down now." : "not shutting down." }`,
+            content: `${client.user?.tag} is shutting down.`,
             ephemeral: true
         })
+        console.log(`[Command: shutoff] ${client.user?.tag} is shutting down.`)
 
         // clean up client instance and stop
         client.destroy()

--- a/src/commands/switchModel.ts
+++ b/src/commands/switchModel.ts
@@ -6,7 +6,7 @@ import { openConfig, UserCommand } from "../utils/index.js";
 
 export const SwitchModel: SlashCommand = {
     name: 'switch-model',
-    description: 'switches current model to preferred model to use.',
+    description: 'switches current model to use.',
 
     // set available user options to pass to the command
     options: [
@@ -55,12 +55,12 @@ export const SwitchModel: SlashCommand = {
 
             // Phase 2: Notify user of failure to find model.
             interaction.editReply({
-                content: `Could not find **${modelInput}** in local model library.\n\nPlease contact an server administrator for access to this model.`
+                content: `Could not find **${modelInput}** in local model library.\n\nPlease contact an server admin for access to this model.`
             })  
         } catch (error) {
             // could not resolve user model switch
             interaction.editReply({
-                content: `Unable to switch user preferred model to **${modelInput}**.\n\n${error}\n\nPossible solution is to request an server administrator run \`/pull-model ${modelInput}\` and try again.`
+                content: `Unable to switch user preferred model to **${modelInput}**.\n\n${error}\n\nPossible solution is to request an server admin run \`/pull-model ${modelInput}\` and try again.`
             })
             return
         }

--- a/src/commands/switchModel.ts
+++ b/src/commands/switchModel.ts
@@ -29,7 +29,7 @@ export const SwitchModel: SlashCommand = {
         if (!channel || !UserCommand.includes(channel.type)) return
 
         try {
-            // Phase 1: Set the model
+            // Phase 1: Switch to the model
             let switchSuccess = false
             await ollama.list()
             .then(response => {
@@ -47,28 +47,20 @@ export const SwitchModel: SlashCommand = {
                 }
             })
             // todo: problem can be here if async messes up
-            if (switchSuccess) return
+            if (switchSuccess) {
+                // set model now that it exists
+                openConfig(`${interaction.user.username}-config.json`, interaction.commandName, modelInput)
+                return
+            }
 
-            // Phase 2: Try to get it regardless
+            // Phase 2: Notify user of failure to find model.
             interaction.editReply({
-                content: `Could not find **${modelInput}** in local model library, trying to pull it now...\n\nThis could take a few moments... Please be patient!`
-            })
-
-            await ollama.pull({
-                model: modelInput
-            })
-
-            // set model now that it exists
-            openConfig(`${interaction.user.username}-config.json`, interaction.commandName, modelInput)
-
-            // We got the model!
-            interaction.editReply({
-                content: `Successfully added and set **${modelInput}** as your preferred model.`
-            })
+                content: `Could not find **${modelInput}** in local model library.\n\nPlease contact an server administrator for access to this model.`
+            })  
         } catch (error) {
             // could not resolve user model switch
             interaction.editReply({
-                content: `Unable to switch user preferred model to **${modelInput}**.\n\n${error}\n\nPossible solution is to run \`/pull-model ${modelInput}\` and try again.`
+                content: `Unable to switch user preferred model to **${modelInput}**.\n\n${error}\n\nPossible solution is to request an server administrator run \`/pull-model ${modelInput}\` and try again.`
             })
             return
         }

--- a/src/commands/threadCreate.ts
+++ b/src/commands/threadCreate.ts
@@ -18,7 +18,7 @@ export const ThreadCreate: SlashCommand = {
         })
 
         // Send a message in the thread
-        thread.send(`Hello ${interaction.user} and others! \n\nIt's nice to meet you. Please talk to me by typing **@${client.user?.username}** with your prompt.`)
+        thread.send(`Hello ${interaction.user} and others! \n\nIt's nice to meet you. Please talk to me by typing **@${client.user?.username}** with your message.`)
 
         // handle storing this chat channel
         openChannelInfo(thread.id, 
@@ -27,7 +27,7 @@ export const ThreadCreate: SlashCommand = {
 
         // user only reply
         return interaction.reply({
-            content: `I can help you in thread **${thread.id}** below.`,
+            content: `I can help you in <#${thread.id}> below.`,
             ephemeral: true
         })
     }

--- a/src/commands/threadPrivateCreate.ts
+++ b/src/commands/threadPrivateCreate.ts
@@ -29,7 +29,7 @@ export const PrivateThreadCreate: SlashCommand = {
 
         // user only reply
         return interaction.reply({
-            content: `I can help you in thread **${thread.id}**. Please refer to the private channel below this one.`,
+            content: `I can help you in <#${thread.id}>.`,
             ephemeral: true
         })
     }


### PR DESCRIPTION
## Changes
* The `pull-model` command is not a admin command. It will notify non-admin users to contact admins to use it.
* The `switch-model` command will no longer be allowed to pull models directly from the ollama library due to possible concerns with storage.
* Made responses from the bot a little less technical for some users.

## Notes
* This addresses some issues found in #141. It might be wise to have some kind of "default model" if all else fails and to just get right into using the bot. It would not be an issue to implement in the future.
* New issue will probably be made for streamlining first setup for the bot. So, when a user first talks, it will set up everything! Server preferences, the User's preference, and pull the designated "default" model. If there is no "default" model then a backup default will be set if not set.
* Another Issue is likely getting rid of the "embed" style as then it will seem more like a regular user.