### PR TITLE
Delete Model Command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: kevinthedang/discord-ollama:0.7.5
+    image: kevinthedang/discord-ollama:0.8.0
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       OLLAMA_IP: ${OLLAMA_IP}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/commands/deleteModel.ts
+++ b/src/commands/deleteModel.ts
@@ -1,0 +1,60 @@
+import { ApplicationCommandOptionType, Client, CommandInteraction } from 'discord.js'
+import { UserCommand, SlashCommand } from '../utils/index.js'
+import { ollama } from '../client.js'
+import { ModelResponse } from 'ollama'
+
+export const DeleteModel: SlashCommand = {
+    name: 'delete-model',
+    description: 'deletes a model from the local list of models. Administrator Only.',
+    
+    // set available user options to pass to the command
+    options: [
+        {
+            name: 'model-name',
+            description: 'the name of the model to delete',
+            type: ApplicationCommandOptionType.String,
+            required: true
+        }
+    ],
+
+    // Delete Model locally stored
+    run: async (client: Client, interaction: CommandInteraction) => {
+        // defer reply to avoid timeout
+        await interaction.deferReply()
+        const modelInput: string = interaction.options.get('model-name')!!.value as string
+
+        // fetch channel and message
+        const channel = await client.channels.fetch(interaction.channelId)
+        if (!channel || !UserCommand.includes(channel.type)) return
+
+        // Admin Command
+        if (!interaction.memberPermissions?.has('Administrator')) {
+            interaction.reply({
+                content: `${interaction.commandName} is an admin command.\n\nPlease contact a server admin to pull the model you want.`,
+                ephemeral: true
+            })
+            return
+        }
+
+        // check if model exists
+        const modelExists: boolean = await ollama.list()
+            .then(response => response.models.some((model: ModelResponse) => model.name.startsWith(modelInput)))
+
+        try {
+            // call ollama to delete model
+            if (modelExists) {
+                await ollama.delete({ model: modelInput })
+                interaction.editReply({
+                    content: `**${modelInput}** was removed from the the library.`
+                })
+            } else
+                throw new Error()
+        } catch (error) {
+            // could not delete the model
+            interaction.reply({
+                content: `Could not delete the **${modelInput}** model. It probably doesn't exist or you spelled it incorrectly.\n\nPlease try again if this is a mistake.`,
+                ephemeral: true
+            })
+        }
+    }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,6 +8,7 @@ import { PrivateThreadCreate } from './threadPrivateCreate.js'
 import { ClearUserChannelHistory } from './cleanUserChannelHistory.js'
 import { PullModel } from './pullModel.js'
 import { SwitchModel } from './switchModel.js'
+import { DeleteModel } from './deleteModel.js'
 
 export default [
     ThreadCreate,
@@ -18,5 +19,6 @@ export default [
     Capacity,
     ClearUserChannelHistory,
     PullModel,
-    SwitchModel
+    SwitchModel,
+    DeleteModel
 ] as SlashCommand[]

--- a/src/commands/pullModel.ts
+++ b/src/commands/pullModel.ts
@@ -1,12 +1,11 @@
-import { ApplicationCommandOptionType, Client, CommandInteraction } from "discord.js";
-import { SlashCommand } from "../utils/commands.js";
-import { ollama } from "../client.js";
-import { ModelResponse } from "ollama";
-import { UserCommand } from "../utils/index.js";
+import { ApplicationCommandOptionType, Client, CommandInteraction } from "discord.js"
+import { ollama } from "../client.js"
+import { ModelResponse } from "ollama"
+import { UserCommand, SlashCommand } from "../utils/index.js"
 
 export const PullModel: SlashCommand = {
     name: 'pull-model',
-    description: 'pulls a model from the ollama model library. Administrator Only',
+    description: 'pulls a model from the ollama model library. Administrator Only.',
 
     // set available user options to pass to the command
     options: [

--- a/src/commands/shutoff.ts
+++ b/src/commands/shutoff.ts
@@ -1,6 +1,5 @@
-import { Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
-import { SlashCommand } from '../utils/commands.js'
-import { AdminCommand } from '../utils/index.js'
+import { Client, CommandInteraction } from 'discord.js'
+import { AdminCommand, SlashCommand } from '../utils/index.js'
 
 export const Shutoff: SlashCommand = {
     name: 'shutoff',

--- a/src/commands/switchModel.ts
+++ b/src/commands/switchModel.ts
@@ -1,8 +1,7 @@
-import { ApplicationCommandOptionType, Client, CommandInteraction } from "discord.js";
-import { SlashCommand } from "../utils/commands.js";
-import { ollama } from "../client.js";
-import { ModelResponse } from "ollama";
-import { openConfig, UserCommand } from "../utils/index.js";
+import { ApplicationCommandOptionType, Client, CommandInteraction } from "discord.js"
+import { ollama } from "../client.js"
+import { ModelResponse } from "ollama"
+import { openConfig, UserCommand, SlashCommand } from "../utils/index.js"
 
 export const SwitchModel: SlashCommand = {
     name: 'switch-model',

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -22,7 +22,7 @@ describe('Commands Existence', () => {
     // test specific commands in the object
     it('references specific commands', () => {
         const commandsString = commands.map(e => e.name).join(', ')
-        expect(commandsString).toBe('thread, private-thread, message-stream, toggle-chat, shutoff, modify-capacity, clear-user-channel-history, pull-model, switch-model')
+        expect(commandsString).toBe('thread, private-thread, message-stream, toggle-chat, shutoff, modify-capacity, clear-user-channel-history, pull-model, switch-model, delete-model')
     })
 })
 


### PR DESCRIPTION
## Changes
* Added the `delete-model` command to delete models locally. This is an Admin command.
* Cleaned up some imports that had semi-colons.
* Updated commands test to include the new command registry.

> [!WARNING]
> All users with the model that was deleted will receive an error message that the model is gone and needs to be pulled to be used.