### PR TITLE
Deprecated ephemeral field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: kevinthedang/discord-ollama:0.8.2
+    image: kevinthedang/discord-ollama:0.8.3
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       OLLAMA_IP: ${OLLAMA_IP}
@@ -28,7 +28,6 @@ services:
     networks:
       ollama-net:
         ipv4_address: ${OLLAMA_IP}
-
     runtime: nvidia             # use Nvidia Container Toolkit for GPU support
     devices:
       - /dev/nvidia0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/commands/capacity.ts
+++ b/src/commands/capacity.ts
@@ -1,4 +1,4 @@
-import { Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
+import { Client, CommandInteraction, ApplicationCommandOptionType, MessageFlags } from 'discord.js'
 import { openConfig, SlashCommand, UserCommand } from '../utils/index.js'
 
 export const Capacity: SlashCommand = {
@@ -28,7 +28,7 @@ export const Capacity: SlashCommand = {
 
         interaction.reply({
             content: `Max message history is now set to \`${interaction.options.get('context-capacity')?.value}\``,
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         })
     }
 }

--- a/src/commands/cleanUserChannelHistory.ts
+++ b/src/commands/cleanUserChannelHistory.ts
@@ -1,4 +1,4 @@
-import { Channel, Client, CommandInteraction, TextChannel } from 'discord.js'
+import { Channel, Client, CommandInteraction, MessageFlags, TextChannel } from 'discord.js'
 import { clearChannelInfo, SlashCommand, UserCommand } from '../utils/index.js'
 
 export const ClearUserChannelHistory: SlashCommand = {
@@ -24,12 +24,12 @@ export const ClearUserChannelHistory: SlashCommand = {
         if (successfulWipe)
             interaction.reply({
                 content: `History cleared in **this channel** cleared for **${interaction.user.username}**.`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
         else
             interaction.reply({
                 content: `History was not be found for **${interaction.user.username}** in **this channel**.\n\nPlease chat with **${client.user?.username}** to start a chat history.`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
     }
 }

--- a/src/commands/deleteModel.ts
+++ b/src/commands/deleteModel.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, Client, CommandInteraction } from 'discord.js'
+import { ApplicationCommandOptionType, Client, CommandInteraction, MessageFlags } from 'discord.js'
 import { UserCommand, SlashCommand } from '../utils/index.js'
 import { ollama } from '../client.js'
 import { ModelResponse } from 'ollama'
@@ -31,7 +31,7 @@ export const DeleteModel: SlashCommand = {
         if (!interaction.memberPermissions?.has('Administrator')) {
             interaction.reply({
                 content: `${interaction.commandName} is an admin command.\n\nPlease contact a server admin to pull the model you want.`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
             return
         }
@@ -53,7 +53,7 @@ export const DeleteModel: SlashCommand = {
             // could not delete the model
             interaction.reply({
                 content: `Could not delete the **${modelInput}** model. It probably doesn't exist or you spelled it incorrectly.\n\nPlease try again if this is a mistake.`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
         }
     }

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -1,4 +1,4 @@
-import { Client, CommandInteraction, ApplicationCommandOptionType } from 'discord.js'
+import { Client, CommandInteraction, ApplicationCommandOptionType, MessageFlags } from 'discord.js'
 import { AdminCommand, openConfig, SlashCommand } from '../utils/index.js'
 
 export const Disable: SlashCommand = {
@@ -25,7 +25,7 @@ export const Disable: SlashCommand = {
         if (!interaction.memberPermissions?.has('Administrator')) {
             interaction.reply({
                 content: `${interaction.commandName} is an admin command.\n\nPlease contact an admin to use this command for you.`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
             return
         }
@@ -37,7 +37,7 @@ export const Disable: SlashCommand = {
 
         interaction.reply({
             content: `${client.user?.username} is now **${interaction.options.get('enabled')?.value ? "enabled" : "disabled"}**.`,
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         })
     }
 }

--- a/src/commands/messageStream.ts
+++ b/src/commands/messageStream.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, Client, CommandInteraction } from 'discord.js'
+import { ApplicationCommandOptionType, Client, CommandInteraction, MessageFlags } from 'discord.js'
 import { openConfig, SlashCommand, UserCommand } from '../utils/index.js'
 
 export const MessageStream: SlashCommand = {
@@ -28,7 +28,7 @@ export const MessageStream: SlashCommand = {
 
         interaction.reply({
             content: `Message streaming is now set to: \`${interaction.options.get('stream')?.value}\``,
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         })
     }
 }

--- a/src/commands/pullModel.ts
+++ b/src/commands/pullModel.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, Client, CommandInteraction } from "discord.js"
+import { ApplicationCommandOptionType, Client, CommandInteraction, MessageFlags } from "discord.js"
 import { ollama } from "../client.js"
 import { ModelResponse } from "ollama"
 import { UserCommand, SlashCommand } from "../utils/index.js"
@@ -31,7 +31,7 @@ export const PullModel: SlashCommand = {
         if (!interaction.memberPermissions?.has('Administrator')) {
             interaction.reply({
                 content: `${interaction.commandName} is an admin command.\n\nPlease contact a server admin to pull the model you want.`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
             return
         }

--- a/src/commands/shutoff.ts
+++ b/src/commands/shutoff.ts
@@ -1,4 +1,4 @@
-import { Client, CommandInteraction } from 'discord.js'
+import { Client, CommandInteraction, MessageFlags } from 'discord.js'
 import { AdminCommand, SlashCommand } from '../utils/index.js'
 
 export const Shutoff: SlashCommand = {
@@ -18,7 +18,7 @@ export const Shutoff: SlashCommand = {
         if (!interaction.memberPermissions?.has('Administrator')) {
             interaction.reply({
                 content: `**Shutdown Aborted:**\n\n${interaction.user.tag}, You do not have permission to shutoff **${client.user?.tag}**.`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
             return // stop from shutting down
         }
@@ -26,7 +26,7 @@ export const Shutoff: SlashCommand = {
         // Shutoff cleared, do it
         interaction.reply({
             content: `${client.user?.tag} is shutting down.`,
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         })
 
         console.log(`[Command: shutoff] ${client.user?.tag} is shutting down.`)

--- a/src/commands/switchModel.ts
+++ b/src/commands/switchModel.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, Client, CommandInteraction } from "discord.js"
+import { ApplicationCommandOptionType, Client, CommandInteraction, Message } from "discord.js"
 import { ollama } from "../client.js"
 import { ModelResponse } from "ollama"
 import { openConfig, UserCommand, SlashCommand } from "../utils/index.js"

--- a/src/commands/switchModel.ts
+++ b/src/commands/switchModel.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, Client, CommandInteraction, Message } from "discord.js"
+import { ApplicationCommandOptionType, Client, CommandInteraction } from "discord.js"
 import { ollama } from "../client.js"
 import { ModelResponse } from "ollama"
 import { openConfig, UserCommand, SlashCommand } from "../utils/index.js"

--- a/src/commands/threadCreate.ts
+++ b/src/commands/threadCreate.ts
@@ -1,4 +1,4 @@
-import { ChannelType, Client, CommandInteraction, TextChannel, ThreadChannel } from 'discord.js'
+import { ChannelType, Client, CommandInteraction, MessageFlags, TextChannel, ThreadChannel } from 'discord.js'
 import { AdminCommand, openChannelInfo, SlashCommand } from '../utils/index.js'
 
 export const ThreadCreate: SlashCommand = {
@@ -26,7 +26,7 @@ export const ThreadCreate: SlashCommand = {
         // user only reply
         return interaction.reply({
             content: `I can help you in <#${thread.id}> below.`,
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         })
     }
 }

--- a/src/commands/threadPrivateCreate.ts
+++ b/src/commands/threadPrivateCreate.ts
@@ -1,4 +1,4 @@
-import { ChannelType, Client, CommandInteraction, TextChannel, ThreadChannel } from 'discord.js'
+import { ChannelType, Client, CommandInteraction, MessageFlags, TextChannel, ThreadChannel } from 'discord.js'
 import { AdminCommand, openChannelInfo, SlashCommand } from '../utils/index.js'
 
 export const PrivateThreadCreate: SlashCommand = {
@@ -27,7 +27,7 @@ export const PrivateThreadCreate: SlashCommand = {
         // user only reply
         return interaction.reply({
             content: `I can help you in <#${thread.id}>.`,
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         })
     }
 }


### PR DESCRIPTION
## Changes
* each command's call to `interaction.reply()` has been updated as follows:
  * old - `interaction.reply({<message>, ephemeral: true})`
  * new - `interaction.reply({<message>, flags: MessageFlags.Ephemeral})`

## Screenshot(s)
![image](https://github.com/user-attachments/assets/f56ac7c9-9599-417c-be43-30743be4abc6)