### PR TITLE
Filter Think Tags Out of Bot Message

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: ./                     # find docker file in designated path
     container_name: discord
     restart: always               # rebuild container always
-    image: kevinthedang/discord-ollama:0.8.6
+    image: kevinthedang/discord-ollama:0.8.7
     environment:
       CLIENT_TOKEN: ${CLIENT_TOKEN}
       OLLAMA_IP: ${OLLAMA_IP}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-ollama",
-  "version": "0.8.5",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-ollama",
-      "version": "0.8.5",
+      "version": "0.8.7",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-ollama",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Ollama Integration into discord",
   "main": "build/index.js",
   "exports": "./build/index.js",

--- a/src/utils/messageNormal.ts
+++ b/src/utils/messageNormal.ts
@@ -56,6 +56,10 @@ export async function normalMessage(
                 response = await blockResponse(params)
                 result = response.message.content
 
+                // check if there is a <think>...</think> sequence from the bot.
+                if (hasThinking(result))
+                    result = result.replace(/<think>[\s\S]*?<\/think>/g, '').trim()
+
                 // check if message length > discord max for normal messages
                 if (result.length > 2000) {
                     sentMessage.edit(result.slice(0, 2000))
@@ -84,4 +88,8 @@ export async function normalMessage(
 
     // return the string representation of ollama query response
     return result
+}
+
+function hasThinking(message: string): boolean {
+    return /<think>[\s\S]*?<\/think>/i.test(message)
 }


### PR DESCRIPTION
## Changes
* Now filters out the <think> tags and anything in-between that shows the bots thinking as just the message it produces is necessary.