### PR TITLE
Helper Scripts, Auto-Update, and Refactored YML

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,11 @@
+services:
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_POLL_INTERVAL=3600  # optional: check every hour
+      - WATCHTOWER_CLEANUP=true       # optional: remove old images
+      - WATCHTOWER_INCLUDE_RESTARTING=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,49 +1,462 @@
-# creates the docker compose
-
-# build individual services 
-services:
-  # setup discord bot container
-  discord:
-    build: ./                     # find docker file in designated path
-    container_name: discord
-    restart: always               # rebuild container always
-    image: kevinthedang/discord-ollama:0.8.7
-    environment:
-      CLIENT_TOKEN: ${CLIENT_TOKEN}
-      OLLAMA_IP: ${OLLAMA_IP}
-      OLLAMA_PORT: ${OLLAMA_PORT}
-      MODEL: ${MODEL}
-    networks:
-      ollama-net:
-        ipv4_address: ${DISCORD_IP}
-    volumes: 
-      - discord:/src/app          # docker will not make this for you, make it yourself
-
-  # setup ollama container
+# ─────────────── Shared Volumes ───────────────
+volumes:
   ollama:
-    image: ollama/ollama:latest   # build the image using ollama
-    container_name: ollama
-    restart: always
-    networks:
-      ollama-net:
-        ipv4_address: ${OLLAMA_IP}
-    runtime: nvidia             # use Nvidia Container Toolkit for GPU support
-    devices:
-      - /dev/nvidia0
-    volumes:
-      - ollama:/root/.ollama
-    ports: 
-      - ${OLLAMA_PORT}:${OLLAMA_PORT}
+  discord:
+  redis:
+  n8n_storage:
+  postgres_storage:
+  qdrant_storage:
 
-# create a network that supports giving addresses withing a specific subnet
+# ─────────────── Network ───────────────
 networks:
   ollama-net:
     driver: bridge
     ipam:
       driver: default
       config:
-        - subnet: ${SUBNET_ADDRESS}/16
+        - subnet: ${SUBNET_ADDRESS}/24
+          gateway: 172.20.0.1
+          ip_range: 172.20.0.128/25        # Docker’s dynamic pool
 
+# ─────────────── n8n template ───────────────
+x-n8n: &service-n8n
+  image: n8nio/n8n:latest
+  restart: unless-stopped
+  env_file: [.env]
+  environment:
+    - DB_TYPE=postgresdb
+    - DB_POSTGRESDB_HOST=postgres
+    - DB_POSTGRESDB_USER=${POSTGRES_USER}
+    - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD}
+    - N8N_DIAGNOSTICS_ENABLED=false
+    - N8N_PERSONALIZATION_ENABLED=false
+    - N8N_ENCRYPTION_KEY=${N8N_ENCRYPTION_KEY}
+    - N8N_USER_MANAGEMENT_JWT_SECRET=${N8N_USER_MANAGEMENT_JWT_SECRET}
+    - N8N_RUNNERS_ENABLED=true
+    - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true
+    - OLLAMA_HOST=ollama:11434
+  networks: [ollama-net]
+
+# ─────────────── Services ───────────────
+services:
+  # ---- Browser-Use WebUI (uses Ollama in this stack) ----
+  browser-use-webui:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        TARGETPLATFORM: ${TARGETPLATFORM:-linux/amd64}
+    container_name: browser-use-webui
+    restart: unless-stopped
+    ports:
+      - "7788:7788"
+      - "6080:6080"
+      - "5901:5901"
+      - "9222:9222"
+    environment:
+      # Point WebUI at the *container* Ollama service (NOT localhost).
+      - OLLAMA_ENDPOINT=http://ollama:11434
+      - DEFAULT_LLM=ollama
+
+      # App / logging
+      - ANONYMIZED_TELEMETRY=false
+      - BROWSER_USE_LOGGING_LEVEL=info
+
+      # Browser / CDP
+      - BROWSER_DEBUGGING_PORT=9222
+      - BROWSER_DEBUGGING_HOST=localhost
+      - USE_OWN_BROWSER=false
+      - KEEP_BROWSER_OPEN=true
+
+      # Display / Playwright
+      - DISPLAY=:99
+      - PLAYWRIGHT_BROWSERS_PATH=/ms-browsers
+      - RESOLUTION=${RESOLUTION:-1920x1080x24}
+      - RESOLUTION_WIDTH=${RESOLUTION_WIDTH:-1920}
+      - RESOLUTION_HEIGHT=${RESOLUTION_HEIGHT:-1080}
+
+      # SECURITY: force you to set this in your .env or shell (no unsafe default)
+      - VNC_PASSWORD=secret
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      # - ./my_chrome_data:/app/data/chrome_data  # Optional: persist browser data
+    shm_size: "2gb"
+    cap_add:
+      - SYS_ADMIN
+    tmpfs:
+      - /tmp
+    networks: [ollama-net]
+    depends_on:
+      ollama:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "5901"]   # VNC port
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # ---- Discord Bot ----
+  discord:
+    build: ./
+    image: kevinthedang/discord-ollama:latest
+    container_name: discord
+    restart: unless-stopped
+    environment:
+      CLIENT_TOKEN: ${CLIENT_TOKEN}
+      OLLAMA_IP: ${OLLAMA_IP}
+      OLLAMA_PORT: ${OLLAMA_PORT}
+      MODEL: ${MODEL}
+      REDIS_IP: ${REDIS_IP}
+      REDIS_PORT: ${REDIS_PORT}
+    networks:
+      ollama-net:
+        ipv4_address: ${DISCORD_IP}
+    volumes:
+      - discord:/src/app
+
+  # ---- Ollama (CPU) ----
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    networks:
+      ollama-net:
+        ipv4_address: ${OLLAMA_IP}
+    volumes:
+      - ollama:/root/.ollama
+    ports:
+      - "${OLLAMA_PORT}:${OLLAMA_PORT}"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+
+  # ---- Redis ----
+  redis:
+    image: redis:latest
+    container_name: redis
+    restart: unless-stopped
+    networks:
+      ollama-net:
+        ipv4_address: ${REDIS_IP}
+    volumes:
+      - redis:/root/.redis
+    ports:
+      - "${REDIS_PORT}:${REDIS_PORT}"
+
+  # ---- Postgres ----
+  postgres:
+    image: postgres:16-alpine
+    container_name: postgres
+    hostname: postgres
+    restart: unless-stopped
+    networks: [ollama-net]
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - postgres_storage:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ---- n8n import helper (one-shot) ----
+  n8n-import:
+    <<: *service-n8n
+    container_name: n8n-import
+    restart: "no"
+    entrypoint: /bin/sh
+    command:
+      - "-c"
+      - |
+        export N8N_RUNNERS_ENABLED=true
+        export N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true
+        if [ -d /demo-data ] && [ "$(ls -A /demo-data 2>/dev/null)" ]; then
+          echo "Demo data found – importing."
+          n8n import:credentials --separate --input=/demo-data/credentials || true
+          n8n import:workflow    --separate --input=/demo-data/workflows   || true
+        else
+          echo "No demo data detected – skipping import."
+        fi
+    volumes:
+      - ./n8n/demo-data:/demo-data
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # ---- n8n main ----
+  n8n:
+    <<: *service-n8n
+    container_name: n8n
+    ports:
+      - "5678:5678"
+    volumes:
+      - n8n_storage:/home/node/.n8n
+      - ./n8n/demo-data:/demo-data
+      - ./shared:/data/shared
+    depends_on:
+      postgres:
+        condition: service_healthy
+      n8n-import:
+        condition: service_completed_successfully
+
+  # ---- Qdrant ----
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    restart: unless-stopped
+    networks: [ollama-net]
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_storage:/qdrant/storage
+      
+# ─────────────── Shared Volumes ───────────────
 volumes:
   ollama:
   discord:
+  redis:
+  n8n_storage:
+  postgres_storage:
+  qdrant_storage:
+
+# ─────────────── Network ───────────────
+networks:
+  ollama-net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: ${SUBNET_ADDRESS}/24
+          gateway: 172.20.0.1
+          ip_range: 172.20.0.128/25        # Docker’s dynamic pool
+
+# ─────────────── n8n template ───────────────
+x-n8n: &service-n8n
+  image: n8nio/n8n:latest
+  restart: unless-stopped
+  env_file: [.env]
+  environment:
+    - DB_TYPE=postgresdb
+    - DB_POSTGRESDB_HOST=postgres
+    - DB_POSTGRESDB_USER=${POSTGRES_USER}
+    - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD}
+    - N8N_DIAGNOSTICS_ENABLED=false
+    - N8N_PERSONALIZATION_ENABLED=false
+    - N8N_ENCRYPTION_KEY=${N8N_ENCRYPTION_KEY}
+    - N8N_USER_MANAGEMENT_JWT_SECRET=${N8N_USER_MANAGEMENT_JWT_SECRET}
+    - N8N_RUNNERS_ENABLED=true
+    - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true
+    - OLLAMA_HOST=ollama:11434
+  networks: [ollama-net]
+
+# ─────────────── Services ───────────────
+services:
+  # ---- Browser-Use WebUI (uses Ollama in this stack) ----
+  browser-use-webui:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        TARGETPLATFORM: ${TARGETPLATFORM:-linux/amd64}
+    container_name: browser-use-webui
+    restart: unless-stopped
+    ports:
+      - "7788:7788"
+      - "6080:6080"
+      - "5901:5901"
+      - "9222:9222"
+    environment:
+      # Point WebUI at the *container* Ollama service (NOT localhost).
+      - OLLAMA_ENDPOINT=http://ollama:11434
+      - DEFAULT_LLM=ollama
+
+      # App / logging
+      - ANONYMIZED_TELEMETRY=false
+      - BROWSER_USE_LOGGING_LEVEL=info
+
+      # Browser / CDP
+      - BROWSER_DEBUGGING_PORT=9222
+      - BROWSER_DEBUGGING_HOST=localhost
+      - USE_OWN_BROWSER=false
+      - KEEP_BROWSER_OPEN=true
+
+      # Display / Playwright
+      - DISPLAY=:99
+      - PLAYWRIGHT_BROWSERS_PATH=/ms-browsers
+      - RESOLUTION=${RESOLUTION:-1920x1080x24}
+      - RESOLUTION_WIDTH=${RESOLUTION_WIDTH:-1920}
+      - RESOLUTION_HEIGHT=${RESOLUTION_HEIGHT:-1080}
+
+      # SECURITY: force you to set this in your .env or shell (no unsafe default)
+      - VNC_PASSWORD=piranesi
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      # - ./my_chrome_data:/app/data/chrome_data  # Optional: persist browser data
+    shm_size: "2gb"
+    cap_add:
+      - SYS_ADMIN
+    tmpfs:
+      - /tmp
+    networks: [ollama-net]
+    depends_on:
+      ollama:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "5901"]   # VNC port
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # ---- Discord Bot ----
+  discord:
+    build: ./
+    image: kevinthedang/discord-ollama:latest
+    container_name: discord
+    restart: unless-stopped
+    environment:
+      CLIENT_TOKEN: ${CLIENT_TOKEN}
+      OLLAMA_IP: ${OLLAMA_IP}
+      OLLAMA_PORT: ${OLLAMA_PORT}
+      MODEL: ${MODEL}
+      REDIS_IP: ${REDIS_IP}
+      REDIS_PORT: ${REDIS_PORT}
+    networks:
+      ollama-net:
+        ipv4_address: ${DISCORD_IP}
+    volumes:
+      - discord:/src/app
+
+  # ---- Ollama (CPU) ----
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    networks:
+      ollama-net:
+        ipv4_address: ${OLLAMA_IP}
+    volumes:
+      - ollama:/root/.ollama
+    ports:
+      - "${OLLAMA_PORT}:${OLLAMA_PORT}"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+
+  # ---- Redis ----
+  redis:
+    image: redis:latest
+    container_name: redis
+    restart: unless-stopped
+    networks:
+      ollama-net:
+        ipv4_address: ${REDIS_IP}
+    volumes:
+      - redis:/root/.redis
+    ports:
+      - "${REDIS_PORT}:${REDIS_PORT}"
+
+  # ---- Postgres ----
+  postgres:
+    image: postgres:16-alpine
+    container_name: postgres
+    hostname: postgres
+    restart: unless-stopped
+    networks: [ollama-net]
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - postgres_storage:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ---- n8n import helper (one-shot) ----
+  n8n-import:
+    <<: *service-n8n
+    container_name: n8n-import
+    restart: "no"
+    entrypoint: /bin/sh
+    command:
+      - "-c"
+      - |
+        export N8N_RUNNERS_ENABLED=true
+        export N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true
+        if [ -d /demo-data ] && [ "$(ls -A /demo-data 2>/dev/null)" ]; then
+          echo "Demo data found – importing."
+          n8n import:credentials --separate --input=/demo-data/credentials || true
+          n8n import:workflow    --separate --input=/demo-data/workflows   || true
+        else
+          echo "No demo data detected – skipping import."
+        fi
+    volumes:
+      - ./n8n/demo-data:/demo-data
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # ---- n8n main ----
+  n8n:
+    <<: *service-n8n
+    container_name: n8n
+    ports:
+      - "5678:5678"
+    volumes:
+      - n8n_storage:/home/node/.n8n
+      - ./n8n/demo-data:/demo-data
+      - ./shared:/data/shared
+    depends_on:
+      postgres:
+        condition: service_healthy
+      n8n-import:
+        condition: service_completed_successfully
+
+  # ---- Qdrant ----
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    restart: unless-stopped
+    networks: [ollama-net]
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_storage:/qdrant/storage
+
+  # ---- Helper: pull devstral (idempotent) ----
+  ollama-pull-devstral:
+    image: ollama/ollama:latest
+    container_name: ollama-pull-devstral
+    restart: on-failure:3
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      - OLLAMA_HOST=ollama:11434         # point CLI at the main service
+    entrypoint: /bin/sh
+    command:
+      - "-c"
+      - |
+        echo "Waiting for Ollama to accept CLI commands..."
+        for i in $(seq 1 18); do     # 18 × 5 s = 90 s max
+          ollama list >/dev/null 2>&1 && break
+          echo "…still waiting"; sleep 5
+        done
+        ollama list >/dev/null 2>&1 || { echo "Timed-out"; exit 1; }
+        ollama show devstral >/dev/null 2>&1 && \
+          echo "Model devstral already present." || \
+          ollama pull devstral
+    networks: [ollama-net]
+    volumes:
+      - ollama:/root/.ollama

--- a/manage-models.sh
+++ b/manage-models.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Interactive Ollama model manager: list / update (pull) / remove
+# Robust I/O, strict error handling, and no DNS reliance.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+trap 'ec=$?; echo "ERROR: line $LINENO exit $ec" >&2; exit $ec' ERR
+
+# -------------------- deps --------------------
+need(){ command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found" >&2; exit 127; }; }
+need curl; need jq; need mktemp
+
+# -------------------- config --------------------
+CURL_TIMEOUT="${CURL_TIMEOUT:-0}"           # 0 = no overall limit (safe for large pulls)
+CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-10}"
+RETRY_COUNT="${RETRY_COUNT:-2}"
+RETRY_DELAY="${RETRY_DELAY:-2}"
+
+# -------------------- env --------------------
+[[ -f .env ]] || { echo "ERROR: .env not found in $(pwd)" >&2; exit 1; }
+set +u
+# shellcheck disable=SC1091
+source .env
+set -u
+
+: "${OLLAMA_IP:?Set OLLAMA_IP in .env}"
+: "${OLLAMA_PORT:?Set OLLAMA_PORT in .env}"
+O_HOST="http://${OLLAMA_IP}:${OLLAMA_PORT}"
+
+# -------------------- I/O --------------------
+TTY_IN="/dev/tty"
+[[ -r "$TTY_IN" ]] || { echo "ERROR: No interactive TTY. Run this in a terminal." >&2; exit 1; }
+
+# -------------------- housekeeping --------------------
+declare -a TMP_FILES=()
+cleanup(){ for f in "${TMP_FILES[@]:-}"; do [[ -f "$f" ]] && rm -f "$f"; done; }
+trap cleanup EXIT
+die(){ echo "ERROR: $*" >&2; exit 1; }
+
+# -------------------- HTTP --------------------
+http_request(){
+  # Usage: http_request METHOD PATH [JSON]
+  local method="${1:?METHOD missing}" path="${2:?PATH missing}" data="${3-}"
+  local url="${O_HOST}${path}" tmp code
+  tmp="$(mktemp)" || die "mktemp failed"; TMP_FILES+=("$tmp")
+
+  if [[ -n "$data" ]]; then
+    code="$(
+      curl -sS \
+           --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+           -m "$CURL_TIMEOUT" \
+           --retry "$RETRY_COUNT" --retry-delay "$RETRY_DELAY" \
+           -w '%{http_code}' -o "$tmp" \
+           -H 'Content-Type: application/json' \
+           -X "$method" "$url" -d "$data"
+    )" || true
+  else
+    code="$(
+      curl -sS \
+           --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+           -m "$CURL_TIMEOUT" \
+           --retry "$RETRY_COUNT" --retry-delay "$RETRY_DELAY" \
+           -w '%{http_code}' -o "$tmp" \
+           -X "$method" "$url"
+    )" || true
+  fi
+
+  HTTP_CODE="${code:-000}"
+  HTTP_BODY_FILE="$tmp"
+
+  if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+    echo "HTTP $HTTP_CODE $url" >&2
+    [[ -s "$tmp" ]] && { jq -C . "$tmp" 2>/dev/null || cat "$tmp"; } >&2
+    return 1
+  fi
+  return 0
+}
+
+# -------------------- API wrappers --------------------
+check_server(){
+  http_request GET /api/version "" || die "Cannot reach ${O_HOST}/api/version"
+  local ver; ver="$(jq -r '.version // empty' "$HTTP_BODY_FILE")"
+  [[ -n "$ver" ]] || die "Unexpected /api/version response"
+  echo "✓ Ollama at $O_HOST (version $ver)"
+}
+
+list_models_json(){ http_request GET /api/tags "" || die "Failed to list models"; cat "$HTTP_BODY_FILE"; }
+
+get_model_names(){
+  # Fills global MODELS[] with names; no "mapfile" dependency.
+  MODELS=()
+  local json; json="$(list_models_json)"
+  while IFS= read -r n; do [[ -n "$n" ]] && MODELS+=("$n"); done < <(jq -r '.models[]? | .name // empty' <<<"$json")
+}
+
+list_models_table(){
+  local json; json="$(list_models_json)"
+  local n; n="$(jq '(.models // []) | length' <<<"$json")"
+  if [[ "$n" -eq 0 ]]; then echo "No models installed."; return 0; fi
+  echo; echo "📦 Installed models:"
+  jq -r '
+    (.models // []) | to_entries |
+    map("\(.key+1)) " + (.value.name) + " | " +
+        (((.value.details.parameter_size // "?") + " / " + (.value.details.quantization_level // "?"))) + " | " +
+        (.value.modified_at // "?")) | .[]' <<<"$json"
+}
+
+pull_model(){
+  local name="${1:?model name missing}"
+  echo "🔄 Pulling \"$name\"..."
+  if http_request POST /api/pull "$(jq -cn --arg v "$name" '{model:$v,stream:false}')" \
+     || http_request POST /api/pull "$(jq -cn --arg v "$name" '{name:$v,stream:false}')"; then
+    jq -C . "$HTTP_BODY_FILE" 2>/dev/null || true
+    echo "✓ Pull completed for $name"
+    return 0
+  else
+    echo "ERROR: Pull failed for $name" >&2
+    return 1
+  fi
+}
+
+delete_model(){
+  local name="${1:?model name missing}"
+  echo "🗑️  Deleting \"$name\"..."
+  if http_request DELETE /api/delete "$(jq -cn --arg v "$name" '{name:$v}')" \
+     || http_request DELETE /api/delete "$(jq -cn --arg v "$name" '{model:$v}')"; then
+    echo "✓ Deleted $name"
+    return 0
+  else
+    echo "ERROR: Delete failed for $name" >&2
+    return 1
+  fi
+}
+
+pull_all(){
+  get_model_names
+  [[ "${#MODELS[@]}" -gt 0 ]] || { echo "No models to update."; return 0; }
+  local ok=0 fail=0
+  for m in "${MODELS[@]}"; do pull_model "$m" && ((ok++)) || ((fail++)); done
+  echo "Update summary: ${ok} succeeded, ${fail} failed."
+}
+
+delete_all(){
+  get_model_names
+  [[ "${#MODELS[@]}" -gt 0 ]] || { echo "No models to remove."; return 0; }
+  printf "Type 'YES' to delete ALL models: " >&2
+  local ack; read -r ack < "$TTY_IN" || { echo "Aborted." >&2; return 1; }
+  [[ "$ack" == "YES" ]] || { echo "Aborted." >&2; return 1; }
+  local ok=0 fail=0
+  for m in "${MODELS[@]}"; do delete_model "$m" && ((ok++)) || ((fail++)); done
+  echo "Delete summary: ${ok} succeeded, ${fail} failed."
+}
+
+# -------------------- UI helpers --------------------
+select_model_prompt(){
+  get_model_names
+  if [[ "${#MODELS[@]}" -eq 0 ]]; then echo "No models installed." >&2; return 1; fi
+
+  # IMPORTANT: UI -> STDERR, only the chosen name -> STDOUT
+  list_models_table >&2
+  echo >&2
+  printf 'Enter number or exact model (blank cancels): ' >&2
+
+  local sel; if ! IFS= read -r sel < "$TTY_IN"; then echo "Cancelled." >&2; return 1; fi
+  [[ -z "$sel" ]] && { echo "Cancelled." >&2; return 1; }
+
+  local out
+  if [[ "$sel" =~ ^[0-9]+$ ]]; then
+    local idx=$((sel-1))
+    (( idx >= 0 && idx < ${#MODELS[@]} )) || { echo "Invalid selection." >&2; return 1; }
+    out="${MODELS[$idx]}"
+  else
+    out="$sel"
+  fi
+
+  printf '%s\n' "$out"   # ONLY the model name to STDOUT
+}
+
+menu_loop(){
+  while true; do
+    echo; list_models_table; echo
+    echo "[U]pdate one  [A] Update all  [R]emove one  [X] Remove all  [P]ull new by name  [L]ist  [Q]uit"
+    printf "Choice: " >&2
+    local choice; if ! read -r choice < "$TTY_IN"; then echo "No input; exiting."; exit 0; fi
+    case "${choice^^}" in
+      U)
+        if name="$(select_model_prompt)"; then pull_model "$name" || true; fi
+        ;;
+      A)
+        printf "Update ALL models? [y/N]: " >&2
+        local yn; read -r yn < "$TTY_IN" || { echo "Skipped."; continue; }
+        [[ "${yn,,}" == "y" ]] && pull_all || echo "Skipped."
+        ;;
+      R)
+        if name="$(select_model_prompt)"; then
+          printf "Delete '%s'? [y/N]: " "$name" >&2
+          local yn; read -r yn < "$TTY_IN" || { echo "Skipped."; continue; }
+          [[ "${yn,,}" == "y" ]] && delete_model "$name" || echo "Skipped."
+        fi
+        ;;
+      X)
+        delete_all || true
+        ;;
+      P)
+        printf "Enter model (e.g., llama3.2:latest): " >&2
+        local m; read -r m < "$TTY_IN" || { echo "No model specified."; continue; }
+        [[ -n "${m:-}" ]] && pull_model "$m" || echo "No model specified."
+        ;;
+      L) : ;;   # re-list
+      Q) echo "Bye."; exit 0 ;;
+      *) echo "Unknown choice." ;;
+    esac
+  done
+}
+
+# -------------------- run --------------------
+check_server
+menu_loop

--- a/pull-models.sh
+++ b/pull-models.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Interactive Ollama model manager (list / update / remove)
+# Uses OLLAMA_IP and OLLAMA_PORT from .env. No DNS required.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# ---------- deps ----------
+need() { command -v "$1" >/dev/null 2>&1 || { printf 'ERROR: %s not found\n' "$1" >&2; exit 1; }; }
+need curl
+need jq
+need mktemp
+
+# ---------- config ----------
+CURL_TIMEOUT="${CURL_TIMEOUT:-0}"            # 0 = no max-time (large pulls)
+CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-10}"
+RETRY_COUNT="${RETRY_COUNT:-2}"
+RETRY_DELAY="${RETRY_DELAY:-2}"
+
+# ---------- env ----------
+[[ -f .env ]] || { echo "ERROR: .env not found in $(pwd)"; exit 1; }
+set +u
+# shellcheck disable=SC1091
+source .env
+set -u
+
+: "${OLLAMA_IP:?Set OLLAMA_IP in .env}"
+: "${OLLAMA_PORT:?Set OLLAMA_PORT in .env}"
+O_HOST="http://${OLLAMA_IP}:${OLLAMA_PORT}"
+
+# ---------- housekeeping ----------
+declare -a TMP_FILES=()
+cleanup(){ for f in "${TMP_FILES[@]:-}"; do [[ -f "$f" ]] && rm -f "$f"; done; }
+trap cleanup EXIT
+die(){ printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ---------- HTTP ----------
+# http_request METHOD PATH [JSON]
+http_request() {
+  local method="${1:?METHOD missing}" path="${2:?PATH missing}" data="${3-}"
+  local url="${O_HOST}${path}" tmp code
+  tmp="$(mktemp)" || die "mktemp failed"; TMP_FILES+=("$tmp")
+  if [[ -n "$data" ]]; then
+    code="$(
+      curl -sS --connect-timeout "$CURL_CONNECT_TIMEOUT" -m "$CURL_TIMEOUT" \
+        --retry "$RETRY_COUNT" --retry-delay "$RETRY_DELAY" \
+        -w '%{http_code}' -o "$tmp" \
+        -H 'Content-Type: application/json' -X "$method" "$url" -d "$data"
+    )" || true
+  else
+    code="$(
+      curl -sS --connect-timeout "$CURL_CONNECT_TIMEOUT" -m "$CURL_TIMEOUT" \
+        --retry "$RETRY_COUNT" --retry-delay "$RETRY_DELAY" \
+        -w '%{http_code}' -o "$tmp" -X "$method" "$url"
+    )" || true
+  fi
+  HTTP_CODE="${code:-000}"; HTTP_BODY_FILE="$tmp"
+  if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+    printf 'HTTP %s %s\n' "$HTTP_CODE" "$url" >&2
+    [[ -s "$tmp" ]] && { jq -C . "$tmp" 2>/dev/null || cat "$tmp"; } >&2
+    return 1
+  fi
+  return 0
+}
+
+# ---------- API ----------
+check_server(){
+  http_request GET /api/version "" || die "Cannot reach ${O_HOST}/api/version"
+  local ver; ver="$(jq -r '.version // empty' "$HTTP_BODY_FILE")"
+  [[ -n "$ver" ]] || die "Unexpected /api/version response"
+  printf '✓ Ollama at %s (version %s)\n' "$O_HOST" "$ver"
+}
+
+list_models_json(){ http_request GET /api/tags "" || die "Failed to list models"; cat "$HTTP_BODY_FILE"; }
+
+declare -a MODELS=()
+get_model_names(){
+  MODELS=()
+  local json; json="$(list_models_json)"
+  mapfile -t MODELS < <(jq -r '.models[]? | .name // empty' <<<"$json") || MODELS=()
+}
+
+list_models_table(){
+  local json; json="$(list_models_json)"
+  local n; n="$(jq '(.models // []) | length' <<<"$json")"
+  if [[ "$n" -eq 0 ]]; then echo "No models installed."; return 0; fi
+  echo; echo "📦 Installed models:"
+  jq -r '
+    (.models // []) | to_entries |
+    map("\(.key+1)) " + (.value.name) + " | " +
+        (((.value.details.parameter_size // "?") + " / " + (.value.details.quantization_level // "?"))) + " | " +
+        (.value.modified_at // "?")) | .[]' <<<"$json"
+}
+
+pull_model(){
+  local name="${1:?model name missing}"
+  echo "🔄 Pulling \"$name\"..."
+  if http_request POST /api/pull "$(jq -cn --arg v "$name" '{model:$v,stream:false}')" \
+     || http_request POST /api/pull "$(jq -cn --arg v "$name" '{name:$v,stream:false}')"; then
+    jq -C . "$HTTP_BODY_FILE" 2>/dev/null || true
+    echo "✓ Pull completed for $name"
+  else
+    die "Pull failed for $name"
+  fi
+}
+
+pull_all(){
+  get_model_names
+  [[ "${#MODELS[@]}" -gt 0 ]] || { echo "No models to update."; return 0; }
+  for m in "${MODELS[@]}"; do pull_model "$m"; done
+}
+
+delete_model(){
+  local name="${1:?model name missing}"
+  echo "🗑️  Deleting \"$name\"..."
+  if http_request DELETE /api/delete "$(jq -cn --arg v "$name" '{name:$v}')" \
+     || http_request DELETE /api/delete "$(jq -cn --arg v "$name" '{model:$v}')"; then
+    echo "✓ Deleted $name"
+  else
+    die "Delete failed for $name"
+  fi
+}
+
+delete_all(){
+  get_model_names
+  [[ "${#MODELS[@]}" -gt 0 ]] || { echo "No models to remove."; return 0; }
+  read -r -p "Type 'YES' to delete ALL models: " ack
+  [[ "$ack" == "YES" ]] || { echo "Aborted."; return 1; }
+  for m in "${MODELS[@]}"; do delete_model "$m"; done
+}
+
+# ---------- UI ----------
+select_model_prompt(){
+  get_model_names
+  [[ "${#MODELS[@]}" -gt 0 ]] || { echo "No models installed."; return 1; }
+  list_models_table; echo
+  local sel=""; read -r -p "Enter number or exact model (blank cancels): " sel || { echo "Cancelled."; return 1; }
+  [[ -z "${sel:-}" ]] && { echo "Cancelled."; return 1; }
+  if [[ "$sel" =~ ^[0-9]+$ ]]; then
+    local idx=$((sel-1)); (( idx>=0 && idx<${#MODELS[@]} )) || { echo "Invalid selection."; return 1; }
+    printf '%s\n' "${MODELS[$idx]}"
+  else
+    printf '%s\n' "$sel"
+  fi
+}
+
+menu_loop(){
+  while true; do
+    echo; list_models_table; echo
+    echo "[U]pdate one  [A] Update all  [R]emove one  [X] Remove all  [P]ull new by name  [L]ist  [Q]uit"
+    local choice=""; read -r -p "Choice: " choice || { echo "Bye."; return 0; }
+    case "${choice^^}" in
+      U) if name="$(select_model_prompt)"; then pull_model "$name"; fi ;;
+      A) read -r -p "Update ALL models? [y/N]: " yn; [[ "${yn,,}" == "y" ]] && pull_all || echo "Skipped." ;;
+      R) if name="$(select_model_prompt)"; then read -r -p "Delete '$name'? [y/N]: " yn; [[ "${yn,,}" == "y" ]] && delete_model "$name" || echo "Skipped."; fi ;;
+      X) delete_all || true ;;
+      P) local m=""; read -r -p "Enter model (e.g., llama3.2:latest): " m; [[ -n "${m:-}" ]] && pull_model "$m" || echo "No model specified." ;;
+      L) : ;;
+      Q) echo "Bye."; return 0 ;;
+      *) echo "Unknown choice."; ;;
+    esac
+  done
+}
+
+# ---------- run ----------
+check_server
+menu_loop


### PR DESCRIPTION
still a little new to GitHub, pardon my lack of ability to separate features into distinct pull requests.

added pull-model and manage-models scripts because it's hard to access the ollama shell from within docker all the time. the scripts use the ollama api so you don't have to log into the container to maintain your models.

added docker compose override file that adds just watchtower, so things get auto-updated. 

reworked docker-compose.yml, this is my personal one but I scrubbed it of personal data I think. 

It's basically a multiplex of Ollama-based tools like n8n and browser-use autoconfigured to work with and around each other. You don't have to merge this one, I just didn't know how to separate it from the rest of the changes. 